### PR TITLE
allow draft barriers to be submitted, apparently status_summary has t…

### DIFF
--- a/reports/forms/new_report_barrier_summary.py
+++ b/reports/forms/new_report_barrier_summary.py
@@ -17,3 +17,7 @@ class NewReportBarrierSummaryForm(forms.Form):
         help_text="Include all your agreed team actions.",
         required=False,
     )
+    status_summary = forms.CharField(
+        label="How did you resolve the problem?",
+        required=False,
+    )

--- a/reports/helpers.py
+++ b/reports/helpers.py
@@ -416,7 +416,7 @@ class ReportFormGroup:
 
     def prepare_payload_summary(self):
         payload = self.summary_form
-        if self.status_form["is_resolved"]:
+        if self.status_form.get("is_resolved"):
             payload["next_steps_summary"] = None
         else:
             payload["status_summary"] = None

--- a/reports/helpers.py
+++ b/reports/helpers.py
@@ -1,9 +1,14 @@
+import json
 from datetime import datetime
+
+from django.conf import settings
+import requests
 
 from reports.constants import FormSessionKeys
 from reports.forms.new_report_barrier_location import HasAdminAreas
 from reports.forms.new_report_barrier_sectors import SectorsAffected
 from reports.forms.new_report_barrier_status import BarrierStatuses
+from reports.models import Report
 from utils.api.client import MarketAccessAPIClient
 
 
@@ -17,7 +22,7 @@ from utils.api.client import MarketAccessAPIClient
 #     "resolved_status",      # Step 1.2 - Status
 #     # ==============================
 #     "status",               # n/a - Barrier status (e.g.: unfinished, open , dormant, etc...)
-#     "status_summary",       # n/a
+#     "status_summary",       # this is set in step 5 - without this the draft barrier cannot be submitted (MAR-221)
 #     "status_date",          # n/a
 #     # ==============================
 #     "export_country",       # Step 2 - Location - UUID
@@ -416,11 +421,28 @@ class ReportFormGroup:
     def prepare_payload_summary(self):
         payload = self.summary_form
         if not payload["next_steps_summary"]:
-            del payload["next_steps_summary"]
+            payload["next_steps_summary"] = None
+            payload["status_summary"] = "n/a"
+        else:
+            payload["status_summary"] = payload["next_steps_summary"]
         return payload
 
     def _update_barrier(self, payload):
-        return self.client.reports.patch(id=self.barrier_id, **payload)
+        # TODO: this really should be in the client, but that doesn't handle JSON strings :/
+        #       the current flow in the client currently converts None to "None" rather then None to null
+        token = self.session.get("sso_token")
+        url = f'{settings.MARKET_ACCESS_API_URI}reports/{self.barrier_id}'
+        headers = {
+            'Authorization': f"Bearer {token}",
+            'Content-Type': 'application/json',
+            'X-User-Agent': '',
+            'X-Forwarded-For': '',
+        }
+        data = json.dumps(payload)
+        response = requests.patch(url, headers=headers, data=data)
+        response.raise_for_status()
+        barrier_data = json.loads(response.text)
+        return Report(barrier_data)
 
     def _create_barrier(self, payload):
         return self.client.reports.create(**payload)

--- a/reports/views.py
+++ b/reports/views.py
@@ -529,12 +529,12 @@ class NewReportBarrierSummaryView(ReportsFormView):
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        context_data["is_resolved"] = self.form_group.status_form["is_resolved"]
+        context_data["is_resolved"] = self.form_group.status_form.get("is_resolved")
         return context_data
 
     def get_form(self, form_class=None):
         form = super().get_form(form_class)
-        if self.form_group.status_form["is_resolved"]:
+        if self.form_group.status_form.get("is_resolved"):
             form.fields["status_summary"].required = True
         return form
 

--- a/reports/views.py
+++ b/reports/views.py
@@ -527,6 +527,17 @@ class NewReportBarrierSummaryView(ReportsFormView):
     extra_paths = {'back': 'reports:barrier_about'}
     form_session_key = FormSessionKeys.SUMMARY
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["is_resolved"] = self.form_group.status_form["is_resolved"]
+        return context_data
+
+    def get_form(self, form_class=None):
+        form = super().get_form(form_class)
+        if self.form_group.status_form["is_resolved"]:
+            form.fields["status_summary"].required = True
+        return form
+
     def success(self):
         self.form_group.save(payload=self.form_group.prepare_payload_summary())
         if self.request.POST.get("action") != "exit":

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -282,7 +282,7 @@
 
             <li class="event-list__item">
 
-                {% if barrier.is_resolved %}
+                {% if barrier.is_resolved or barrier.is_partially_resolved %}
 
                     <h4 class="event-list__item__heading">Attach any useful documents</h4>
                     <p class="event-list__item__text">

--- a/templates/reports/new_report_barrier_summary.html
+++ b/templates/reports/new_report_barrier_summary.html
@@ -31,7 +31,21 @@
                     </span>
                 </div>
             </div>
-
+            {% if is_resolved %}
+            <div class="{% form_group_classes form.status_summary.errors %}">
+                <label class="govuk-label govuk-label--s" for="next-steps">
+                    {{ form.status_summary.label }}
+                </label>
+                {% form_field_error form "status_summary" %}
+                <span id="next-steps-hint" class="govuk-hint">
+                    {{ form.status_summary.help_text }}
+                </span>
+                <textarea class="govuk-textarea" id="next-steps"
+                          name="{{ form.status_summary.name }}"
+                          rows="5"
+                          aria-describedby="next-steps-hint">{{ form.initial.status_summary }}</textarea>
+            </div>
+            {% else %}
             <div class="{% form_group_classes form.next_steps_summary.errors %}">
                 <label class="govuk-label govuk-label--s" for="next-steps">
                     {{ form.next_steps_summary.label }}
@@ -45,6 +59,8 @@
                           rows="5"
                           aria-describedby="next-steps-hint">{{ form.initial.next_steps_summary }}</textarea>
             </div>
+            {% endif %}
+
 
             <input type="submit" value="Save and continue" class="govuk-button">
             <button type="submit" class="govuk-button button--secondary" name="action" value="exit">Save and exit</button>

--- a/tests/reports/test_summary_views.py
+++ b/tests/reports/test_summary_views.py
@@ -70,7 +70,7 @@ class SummaryViewTestCase(ReportsTestCase):
 
     @patch("utils.api.client.ReportsResource.submit")
     @patch("utils.api.client.ReportsResource.get")
-    @patch("utils.api.resources.APIResource.patch")
+    @patch("reports.helpers.ReportFormGroup._update_barrier")
     def test_save_and_continue_redirects_to_correct_view(self, mock_update, mock_get, mock_submit):
         """
         Clicking on `Save and continue` button should update the draft barrier
@@ -92,7 +92,7 @@ class SummaryViewTestCase(ReportsTestCase):
 
     @patch("utils.api.client.ReportsResource.submit")
     @patch("utils.api.client.ReportsResource.get")
-    @patch("utils.api.resources.APIResource.patch")
+    @patch("reports.helpers.ReportFormGroup._update_barrier")
     def test_button_save_and_exit_redirects_to_correct_view(self, mock_update, mock_get, mock_submit):
         """
         Clicking on `Save and exit` button should update the draft barrier


### PR DESCRIPTION
…o be set as well - the node app sets that instead of next_steps_summary, pyfe will set both t be the same for now