### PR TITLE
MAR-267: Remove character limit text from barrier summary

### DIFF
--- a/templates/reports/new_report_barrier_summary.html
+++ b/templates/reports/new_report_barrier_summary.html
@@ -26,9 +26,6 @@
                               name="{{ form.problem_description.name }}"
                               rows="5"
                               aria-describedby="description-hint description-info">{{ form.initial.problem_description }}</textarea>
-                    <span id="description-info" class="govuk-hint govuk-character-count__message" aria-live="polite">
-                        You have 300 characters remaining
-                    </span>
                 </div>
             </div>
             {% if is_resolved %}
@@ -70,14 +67,3 @@
 
 
 {% endblock %}
-
-
-{% block body_script %}
-    {{ block.super }}
-    <script>
-        if( ma.components.CharacterCount ){
-            new ma.components.CharacterCount( '.govuk-character-count' );
-        }
-	</script>
-{% endblock %}
-


### PR DESCRIPTION
Remove the character limit from the barrier summary for now.
I think the plan is to reinstate the limit later once decided what the limit should be along with some help text.