### PR TITLE
Default HistoryItem class

### DIFF
--- a/barriers/models/history/assessments.py
+++ b/barriers/models/history/assessments.py
@@ -1,4 +1,4 @@
-from .base import BaseHistoryItem
+from .base import BaseHistoryItem, GenericHistoryItem
 from .documents import BaseDocumentsHistoryItem
 from .utils import PolymorphicBase
 
@@ -67,4 +67,5 @@ class AssessmentHistoryItem(PolymorphicBase):
         ImportMarketSizeHistoryItem,
         ValueToEconomyHistoryItem,
     )
+    default_subclass = GenericHistoryItem
     class_lookup = {}

--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -1,5 +1,5 @@
 from barriers.constants import ARCHIVED_REASON
-from .base import BaseHistoryItem
+from .base import BaseHistoryItem, GenericHistoryItem
 from .utils import PolymorphicBase
 from utils.metadata import Statuses
 
@@ -178,4 +178,5 @@ class BarrierHistoryItem(PolymorphicBase):
         TagsHistoryItem,
         TitleHistoryItem,
     )
+    default_subclass = GenericHistoryItem
     class_lookup = {}

--- a/barriers/models/history/base.py
+++ b/barriers/models/history/base.py
@@ -41,3 +41,13 @@ class BaseHistoryItem(APIModel):
 
     def get_value(self, value):
         return value
+
+
+class GenericHistoryItem(BaseHistoryItem):
+    """
+    HistoryItem class used when unable to find a match for the model and field
+    """
+
+    @property
+    def field_name(self):
+        return self.field.title()

--- a/barriers/models/history/notes.py
+++ b/barriers/models/history/notes.py
@@ -1,4 +1,4 @@
-from .base import BaseHistoryItem
+from .base import BaseHistoryItem, GenericHistoryItem
 from .documents import BaseDocumentsHistoryItem
 from .utils import PolymorphicBase
 
@@ -24,4 +24,5 @@ class NoteHistoryItem(PolymorphicBase):
         DocumentsHistoryItem,
         TextHistoryItem,
     )
+    default_subclass = GenericHistoryItem
     class_lookup = {}

--- a/barriers/models/history/team_members.py
+++ b/barriers/models/history/team_members.py
@@ -1,4 +1,4 @@
-from .base import BaseHistoryItem
+from .base import BaseHistoryItem, GenericHistoryItem
 from .utils import PolymorphicBase
 
 
@@ -15,4 +15,5 @@ class TeamMemberHistoryItem(PolymorphicBase):
     model = "team_member"
     key = "field"
     subclasses = (UserHistoryItem,)
+    default_subclass = GenericHistoryItem
     class_lookup = {}

--- a/barriers/models/history/utils.py
+++ b/barriers/models/history/utils.py
@@ -8,12 +8,13 @@ class PolymorphicBase:
     key = None
     class_lookup = {}
     subclasses = tuple()
+    default_subclass = None
 
     def __new__(cls, data):
         if not cls.class_lookup:
             cls.init_class_lookup()
 
-        subclass = cls.class_lookup.get(data[cls.key])
+        subclass = cls.class_lookup.get(data[cls.key], cls.default_subclass)
         return subclass(data)
 
     @classmethod


### PR DESCRIPTION
Ensures the frontend history page won't break when the API adds or changes field names. This will help with releases, so that we're able to deploy the API without breaking the frontend.