### PR TITLE
MAR-276: Sensitive summaries

### DIFF
--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -40,7 +40,7 @@ class UpdateBarrierProductForm(APIFormMixin, forms.Form):
 
 class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
     summary = forms.CharField(
-        label=("Provide a summary of the problem and how you became aware of it"),
+        label="Give us a summary of the barrier and how you found out about it",
         widget=forms.Textarea,
         error_messages={"required": "Enter a brief description for this barrier"},
     )

--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -3,7 +3,11 @@ from django import forms
 from .mixins import APIFormMixin
 
 from utils.api.client import MarketAccessAPIClient
-from utils.forms import ChoiceFieldWithHelpText, MultipleChoiceFieldWithHelpText
+from utils.forms import (
+    ChoiceFieldWithHelpText,
+    MultipleChoiceFieldWithHelpText,
+    YesNoBooleanField,
+)
 
 
 class UpdateBarrierTitleForm(APIFormMixin, forms.Form):
@@ -40,28 +44,14 @@ class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
         widget=forms.Textarea,
         error_messages={"required": "Enter a brief description for this barrier"},
     )
-    is_summary_sensitive = forms.ChoiceField(
+    is_summary_sensitive = YesNoBooleanField(
         label="Does the summary contain OFFICIAL-SENSITIVE information?",
-        choices=(
-            ("yes", "Yes"),
-            ("no", "No"),
-        ),
         error_messages={
             "required": (
                 "Indicate if summary contains OFFICIAL-SENSITIVE information or not"
             )
         },
     )
-
-    def clean_is_summary_sensitive(self):
-        value = self.cleaned_data["is_summary_sensitive"]
-        if value == "yes":
-            return True
-        elif value == "no":
-            return False
-        raise forms.ValidationError(
-            "Indicate if summary contains OFFICIAL-SENSITIVE information or not"
-        )
 
     def save(self):
         client = MarketAccessAPIClient(self.token)

--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -40,11 +40,29 @@ class UpdateBarrierDescriptionForm(APIFormMixin, forms.Form):
         widget=forms.Textarea,
         error_messages={"required": "Enter a brief description for this barrier"},
     )
+    is_summary_sensitive = forms.ChoiceField(
+        label="Does the summary contain OFFICIAL-SENSITIVE information?",
+        choices=(
+            ("yes", "Yes"),
+            ("no", "No"),
+        ),
+        error_messages={"required": "Select whether the summary is sensitive"},
+    )
+
+    def clean_is_summary_sensitive(self):
+        value = self.cleaned_data["is_summary_sensitive"]
+        if value == "yes":
+            return True
+        elif value == "no":
+            return False
+        raise forms.ValidationError("Select whether the summary is sensitive")
 
     def save(self):
         client = MarketAccessAPIClient(self.token)
         client.barriers.patch(
-            id=self.id, problem_description=self.cleaned_data["description"]
+            id=self.id,
+            problem_description=self.cleaned_data["description"],
+            is_summary_sensitive=self.cleaned_data["is_summary_sensitive"],
         )
 
 

--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -61,7 +61,7 @@ class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
         client = MarketAccessAPIClient(self.token)
         client.barriers.patch(
             id=self.id,
-            problem_description=self.cleaned_data["summary"],
+            summary=self.cleaned_data["summary"],
             is_summary_sensitive=self.cleaned_data["is_summary_sensitive"],
         )
 

--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -34,8 +34,8 @@ class UpdateBarrierProductForm(APIFormMixin, forms.Form):
         client.barriers.patch(id=self.id, product=self.cleaned_data["product"])
 
 
-class UpdateBarrierDescriptionForm(APIFormMixin, forms.Form):
-    description = forms.CharField(
+class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
+    summary = forms.CharField(
         label=("Provide a summary of the problem and how you became aware of it"),
         widget=forms.Textarea,
         error_messages={"required": "Enter a brief description for this barrier"},
@@ -61,7 +61,7 @@ class UpdateBarrierDescriptionForm(APIFormMixin, forms.Form):
         client = MarketAccessAPIClient(self.token)
         client.barriers.patch(
             id=self.id,
-            problem_description=self.cleaned_data["description"],
+            problem_description=self.cleaned_data["summary"],
             is_summary_sensitive=self.cleaned_data["is_summary_sensitive"],
         )
 

--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -46,7 +46,11 @@ class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
             ("yes", "Yes"),
             ("no", "No"),
         ),
-        error_messages={"required": "Select whether the summary is sensitive"},
+        error_messages={
+            "required": (
+                "Indicate if summary contains OFFICIAL-SENSITIVE information or not"
+            )
+        },
     )
 
     def clean_is_summary_sensitive(self):
@@ -55,7 +59,9 @@ class UpdateBarrierSummaryForm(APIFormMixin, forms.Form):
             return True
         elif value == "no":
             return False
-        raise forms.ValidationError("Select whether the summary is sensitive")
+        raise forms.ValidationError(
+            "Indicate if summary contains OFFICIAL-SENSITIVE information or not"
+        )
 
     def save(self):
         client = MarketAccessAPIClient(self.token)

--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -52,12 +52,9 @@ class DescriptionHistoryItem(BaseHistoryItem):
         return value or ""
 
 
-class EUExitRelatedHistoryItem(BaseHistoryItem):
-    field = "eu_exit_related"
-    field_name = "Related to EU exit"
-
-    def get_value(self, value):
-        return self.metadata.get_eu_exit_related_text(value)
+class IsSummarySensitiveHistoryItem(BaseHistoryItem):
+    field = "is_summary_sensitive"
+    field_name = "Summary status"
 
 
 class LocationHistoryItem(BaseHistoryItem):
@@ -167,7 +164,7 @@ class BarrierHistoryItem(PolymorphicBase):
         CategoriesHistoryItem,
         CompaniesHistoryItem,
         DescriptionHistoryItem,
-        EUExitRelatedHistoryItem,
+        IsSummarySensitiveHistoryItem,
         LocationHistoryItem,
         ProductHistoryItem,
         PriorityHistoryItem,

--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -44,14 +44,6 @@ class CompaniesHistoryItem(BaseHistoryItem):
         return [company["name"] for company in value or []]
 
 
-class DescriptionHistoryItem(BaseHistoryItem):
-    field = "problem_description"
-    field_name = "Summary"
-
-    def get_value(self, value):
-        return value or ""
-
-
 class IsSummarySensitiveHistoryItem(BaseHistoryItem):
     field = "is_summary_sensitive"
     field_name = "Summary status"
@@ -136,6 +128,14 @@ class StatusHistoryItem(BaseHistoryItem):
         return value
 
 
+class SummaryHistoryItem(BaseHistoryItem):
+    field = "problem_description"
+    field_name = "Summary"
+
+    def get_value(self, value):
+        return value or ""
+
+
 class TagsHistoryItem(BaseHistoryItem):
     field = "tags"
     field_name = "Barrier tags"
@@ -163,7 +163,6 @@ class BarrierHistoryItem(PolymorphicBase):
         ArchivedHistoryItem,
         CategoriesHistoryItem,
         CompaniesHistoryItem,
-        DescriptionHistoryItem,
         IsSummarySensitiveHistoryItem,
         LocationHistoryItem,
         ProductHistoryItem,
@@ -172,6 +171,7 @@ class BarrierHistoryItem(PolymorphicBase):
         SectorsHistoryItem,
         SourceHistoryItem,
         StatusHistoryItem,
+        SummaryHistoryItem,
         TagsHistoryItem,
         TitleHistoryItem,
     )

--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -129,7 +129,7 @@ class StatusHistoryItem(BaseHistoryItem):
 
 
 class SummaryHistoryItem(BaseHistoryItem):
-    field = "problem_description"
+    field = "summary"
     field_name = "Summary"
 
     def get_value(self, value):

--- a/barriers/urls.py
+++ b/barriers/urls.py
@@ -101,8 +101,6 @@ urlpatterns = [
 
     path("barriers/<uuid:barrier_id>/edit/title/", BarrierEditTitle.as_view(), name="edit_title"),
     path("barriers/<uuid:barrier_id>/edit/product/", BarrierEditProduct.as_view(), name="edit_product"),
-    # TODO: deprecate description url
-    path("barriers/<uuid:barrier_id>/edit/description/", BarrierEditSummary.as_view(), name="edit_description"),
     path("barriers/<uuid:barrier_id>/edit/summary/", BarrierEditSummary.as_view(), name="edit_summary"),
     path("barriers/<uuid:barrier_id>/edit/source/", BarrierEditSource.as_view(), name="edit_source"),
     path("barriers/<uuid:barrier_id>/edit/priority/", BarrierEditPriority.as_view(), name="edit_priority"),

--- a/barriers/urls.py
+++ b/barriers/urls.py
@@ -31,8 +31,8 @@ from .views.documents import DownloadDocument
 from .views.edit import (
     BarrierEditTitle,
     BarrierEditProduct,
-    BarrierEditDescription,
     BarrierEditSource,
+    BarrierEditSummary,
     BarrierEditPriority,
     BarrierEditProblemStatus,
     BarrierEditTags,
@@ -101,7 +101,9 @@ urlpatterns = [
 
     path("barriers/<uuid:barrier_id>/edit/title/", BarrierEditTitle.as_view(), name="edit_title"),
     path("barriers/<uuid:barrier_id>/edit/product/", BarrierEditProduct.as_view(), name="edit_product"),
-    path("barriers/<uuid:barrier_id>/edit/description/", BarrierEditDescription.as_view(), name="edit_description"),
+    # TODO: deprecate description url
+    path("barriers/<uuid:barrier_id>/edit/description/", BarrierEditSummary.as_view(), name="edit_description"),
+    path("barriers/<uuid:barrier_id>/edit/summary/", BarrierEditSummary.as_view(), name="edit_summary"),
     path("barriers/<uuid:barrier_id>/edit/source/", BarrierEditSource.as_view(), name="edit_source"),
     path("barriers/<uuid:barrier_id>/edit/priority/", BarrierEditPriority.as_view(), name="edit_priority"),
     path("barriers/<uuid:barrier_id>/edit/problem-status/", BarrierEditProblemStatus.as_view(), name="edit_problem_status"),

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -4,8 +4,8 @@ from .mixins import APIBarrierFormViewMixin
 from barriers.forms.edit import (
     UpdateBarrierTitleForm,
     UpdateBarrierProductForm,
-    UpdateBarrierDescriptionForm,
     UpdateBarrierSourceForm,
+    UpdateBarrierSummaryForm,
     UpdateBarrierPriorityForm,
     UpdateBarrierProblemStatusForm,
     UpdateBarrierTagsForm,
@@ -29,13 +29,13 @@ class BarrierEditProduct(APIBarrierFormViewMixin, FormView):
         return {"product": self.barrier.product}
 
 
-class BarrierEditDescription(APIBarrierFormViewMixin, FormView):
-    template_name = "barriers/edit/description.html"
-    form_class = UpdateBarrierDescriptionForm
+class BarrierEditSummary(APIBarrierFormViewMixin, FormView):
+    template_name = "barriers/edit/summary.html"
+    form_class = UpdateBarrierSummaryForm
 
     def get_initial(self):
         initial = {
-            "description": self.barrier.problem_description,
+            "summary": self.barrier.problem_description,
             "is_summary_sensitive": None,
         }
         if self.barrier.is_summary_sensitive is True:

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -34,15 +34,10 @@ class BarrierEditSummary(APIBarrierFormViewMixin, FormView):
     form_class = UpdateBarrierSummaryForm
 
     def get_initial(self):
-        initial = {
+        return {
             "summary": self.barrier.summary,
-            "is_summary_sensitive": None,
+            "is_summary_sensitive": self.barrier.is_summary_sensitive,
         }
-        if self.barrier.is_summary_sensitive is True:
-            initial["is_summary_sensitive"] = "yes"
-        elif self.barrier.is_summary_sensitive is False:
-            initial["is_summary_sensitive"] = "no"
-        return initial
 
 
 class BarrierEditSource(APIBarrierFormViewMixin, FormView):

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -34,7 +34,15 @@ class BarrierEditDescription(APIBarrierFormViewMixin, FormView):
     form_class = UpdateBarrierDescriptionForm
 
     def get_initial(self):
-        return {"description": self.barrier.problem_description}
+        if self.barrier.is_summary_sensitive is True:
+            is_summary_sensitive_value = "yes"
+        elif self.barrier.is_summary_sensitive is False:
+            is_summary_sensitive_value = "no"
+
+        return {
+            "description": self.barrier.problem_description,
+            "is_summary_sensitive": is_summary_sensitive_value,
+        }
 
 
 class BarrierEditSource(APIBarrierFormViewMixin, FormView):

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -34,15 +34,15 @@ class BarrierEditDescription(APIBarrierFormViewMixin, FormView):
     form_class = UpdateBarrierDescriptionForm
 
     def get_initial(self):
-        if self.barrier.is_summary_sensitive is True:
-            is_summary_sensitive_value = "yes"
-        elif self.barrier.is_summary_sensitive is False:
-            is_summary_sensitive_value = "no"
-
-        return {
+        initial = {
             "description": self.barrier.problem_description,
-            "is_summary_sensitive": is_summary_sensitive_value,
+            "is_summary_sensitive": None,
         }
+        if self.barrier.is_summary_sensitive is True:
+            initial["is_summary_sensitive"] = "yes"
+        elif self.barrier.is_summary_sensitive is False:
+            initial["is_summary_sensitive"] = "no"
+        return initial
 
 
 class BarrierEditSource(APIBarrierFormViewMixin, FormView):

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -35,7 +35,7 @@ class BarrierEditSummary(APIBarrierFormViewMixin, FormView):
 
     def get_initial(self):
         initial = {
-            "summary": self.barrier.problem_description,
+            "summary": self.barrier.summary,
             "is_summary_sensitive": None,
         }
         if self.barrier.is_summary_sensitive is True:

--- a/core/static/css/_main.scss
+++ b/core/static/css/_main.scss
@@ -43,6 +43,8 @@ $govuk-font-family-tabular: Arial,'Helvetica Neue',Helvetica,sans-serif;
 @import 'govuk-frontend/components/file-upload/file-upload';
 @import 'govuk-frontend/components/character-count/character-count';
 
+@import 'govuk-custom/components/warning-text/warning-text';
+
 @import 'app-settings/colours';
 
 @import 'layout';

--- a/core/static/css/_main.scss
+++ b/core/static/css/_main.scss
@@ -42,7 +42,9 @@ $govuk-font-family-tabular: Arial,'Helvetica Neue',Helvetica,sans-serif;
 @import 'govuk-frontend/components/date-input/date-input';
 @import 'govuk-frontend/components/file-upload/file-upload';
 @import 'govuk-frontend/components/character-count/character-count';
+@import 'govuk-frontend/components/details/details';
 
+@import 'govuk-custom/components/details/details';
 @import 'govuk-custom/components/warning-text/warning-text';
 
 @import 'app-settings/colours';

--- a/core/static/css/govuk-custom/components/details/_details.scss
+++ b/core/static/css/govuk-custom/components/details/_details.scss
@@ -1,0 +1,7 @@
+.govuk-details__list {
+    padding: 0 0 0 govuk-em( 20, 16 );
+}
+
+.govuk-details__heading {
+    margin-bottom: govuk-em( 4, 16 );
+}

--- a/core/static/css/govuk-custom/components/warning-text/_warning-text.scss
+++ b/core/static/css/govuk-custom/components/warning-text/_warning-text.scss
@@ -1,0 +1,11 @@
+.govuk-warning-text__icon--small {
+    min-width: 24px;
+    min-height: 24px;
+    font-size: 24px;
+    line-height: 24px;
+}
+
+.govuk-warning-text__text--small {
+    font-size: 1em;
+    padding-left: 40px;
+}

--- a/core/static/css/govuk-frontend/components/warning-text/_warning-text.scss
+++ b/core/static/css/govuk-frontend/components/warning-text/_warning-text.scss
@@ -5,9 +5,6 @@
 @include govuk-exports("govuk/component/warning-text") {
 
   .govuk-warning-text {
-    @include govuk-font($size: 19);
-    @include govuk-text-colour;
-
     position: relative;
     @include govuk-responsive-margin(6, "bottom");
     padding: govuk-spacing(2) 0;
@@ -23,13 +20,15 @@
     display: inline-block;
 
     position: absolute;
-    top: 50%;
     left: 0;
 
-    min-width: 32px;
+    min-width: 29px;
     min-height: 29px;
-    margin-top: -20px; // Half the height of the circle (adjusted for NTA)
-    padding-top: 3px;
+    margin-top: -7px;
+
+    @include govuk-media-query($from: tablet) {
+      margin-top: -5px;
+    }
 
     // When a user customises their colours the background colour will often be removed.
     // Adding a border to the component keeps it's shape as a circle.
@@ -39,21 +38,20 @@
     color: govuk-colour("white");
     background: govuk-colour("black");
 
-    font-size: 1.6em;
+    font-size: 30px;
     line-height: 29px;
 
     text-align: center;
 
     // Prevent the exclamation mark from being included when the warning text
     // is copied, for example.
-    -webkit-user-select: none;
-       -moz-user-select: none;
-        -ms-user-select: none;
-            user-select: none;
+    user-select: none;
   }
 
   .govuk-warning-text__text {
+    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-text-colour;
     display: block;
-    padding-left: 50px;
+    padding-left: 45px;
   }
 }

--- a/reports/forms/new_report_barrier_summary.py
+++ b/reports/forms/new_report_barrier_summary.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from utils.forms import YesNoBooleanField
+
 
 class NewReportBarrierSummaryForm(forms.Form):
     summary = forms.CharField(
@@ -10,6 +12,14 @@ class NewReportBarrierSummaryForm(forms.Form):
                   "political context; the HS code; and when the problem started.",
         error_messages={
             'required': "Enter a brief description for this barrier"
+        },
+    )
+    is_summary_sensitive = YesNoBooleanField(
+        label="Does the summary contain OFFICIAL-SENSITIVE information?",
+        error_messages={
+            "required": (
+                "Indicate if summary contains OFFICIAL-SENSITIVE information or not"
+            )
         },
     )
     next_steps_summary = forms.CharField(

--- a/reports/forms/new_report_barrier_summary.py
+++ b/reports/forms/new_report_barrier_summary.py
@@ -2,7 +2,7 @@ from django import forms
 
 
 class NewReportBarrierSummaryForm(forms.Form):
-    problem_description = forms.CharField(
+    summary = forms.CharField(
         label="Describe the barrier",
         help_text="Include how the barrier is affecting the export or investment "
                   "and why the barrier exists. For example, because of specific "

--- a/reports/helpers.py
+++ b/reports/helpers.py
@@ -30,7 +30,7 @@ from utils.api.client import MarketAccessAPIClient
 #     "barrier_title",        # Step 4 - About - STR
 #     "tags"                  # Step 4 - About - LIST of IDS
 #     # ==============================
-#     "problem_description",  # Step 5 - Summary - STR
+#     "summary",  # Step 5 - Summary - STR
 #     "next_steps_summary",   # Step 5 - Summary - STR
 #     # ==============================
 #     "progress",             # n/a
@@ -322,7 +322,7 @@ class ReportFormGroup:
 
     def get_summary_form(self):
         data = {
-            "problem_description": self.barrier.data.get("problem_description") or "",
+            "summary": self.barrier.data.get("summary") or "",
             "next_steps_summary": self.barrier.data.get("next_steps_summary") or "",
             "status_summary": self.barrier.data.get("status_summary") or "",
         }

--- a/reports/helpers.py
+++ b/reports/helpers.py
@@ -323,6 +323,7 @@ class ReportFormGroup:
     def get_summary_form(self):
         data = {
             "summary": self.barrier.data.get("summary") or "",
+            "is_summary_sensitive": self.barrier.data.get("is_summary_sensitive"),
             "next_steps_summary": self.barrier.data.get("next_steps_summary") or "",
             "status_summary": self.barrier.data.get("status_summary") or "",
         }

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -66,9 +66,9 @@
                 {% endif %}
 
                 {% if barrier.is_summary_sensitive is not False %}
-                    <div class="govuk-warning-text govuk-!-margin-bottom-2">
-                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-                        <strong class="govuk-warning-text__text">
+                    <div class="govuk-warning-text govuk-!-margin-bottom-0 govuk-!-margin-top-2">
+                        <span class="govuk-warning-text__icon govuk-warning-text__icon--small" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text govuk-warning-text__text--small">
                             <span class="govuk-warning-text__assistive">Warning</span>
                             {% if barrier.is_summary_sensitive is True %}
                                 This summary contains OFFICIAL-SENSITIVE information.

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -64,6 +64,20 @@
                 {% if not barrier.archived %}
                 <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_description' barrier.id %}">Edit</a>
                 {% endif %}
+
+                {% if barrier.is_summary_sensitive is not False %}
+                    <div class="govuk-warning-text govuk-!-margin-bottom-2">
+                        <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                        <strong class="govuk-warning-text__text">
+                            <span class="govuk-warning-text__assistive">Warning</span>
+                            {% if barrier.is_summary_sensitive is True %}
+                                This summary contains OFFICIAL-SENSITIVE information.
+                            {% else %}
+                                This summary has not been given a security classification.
+                            {% endif %}
+                        </strong>
+                    </div>
+                {% endif %}
             </dd>
 
             <dt class="summary-group__list__key">Barrier type</dt>

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -62,7 +62,7 @@
             <dd class="summary-group__list__value">
                 {{ barrier.problem_description|escape|linebreaksbr }}
                 {% if not barrier.archived %}
-                <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_description' barrier.id %}">Edit</a>
+                <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_summary' barrier.id %}">Edit</a>
                 {% endif %}
 
                 {% if barrier.is_summary_sensitive is not False %}

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -60,7 +60,7 @@
 
             <dt class="summary-group__list__key">Barrier summary</dt>
             <dd class="summary-group__list__value">
-                {{ barrier.problem_description|escape|linebreaksbr }}
+                {{ barrier.summary|escape|linebreaksbr }}
                 {% if not barrier.archived %}
                 <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_summary' barrier.id %}">Edit</a>
                 {% endif %}

--- a/templates/barriers/edit/description.html
+++ b/templates/barriers/edit/description.html
@@ -22,6 +22,54 @@
             <textarea class="govuk-textarea" name="description" rows="5">{% if form.description.value %}{{ form.description.value }}{% endif %}</textarea>
         </div>
 
+        <div id="{{ form.is_summary_sensitive.name }}" class="govuk-form-group{% if form.is_summary_sensitive.errors %} govuk-form-group--error{% endif %}">
+
+            {% form_field_error form "is_summary_sensitive" %}
+
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                        {{ form.is_summary_sensitive.label }}
+                    </legend>
+
+                    <a>What is OFFICIAL-SENSITIVE information?</a>
+
+                    <div class="govuk-inset-text">
+                        <p>The OFFICIAL classification is used for most Government business and public service delivery. OFFICIAL-SENSITIVE applies where loss or disclosure would:
+
+                            <ul>
+                                <li>have damaging consequences for DIT and the government</li>
+                                <li>cause significant distress for an individual or group of people, such as sensitive personal information</li>
+                            </ul>
+                        </p>
+
+                        <p>OFFICIAL-SENSITIVE includes:
+                            <ul>
+                                <li>sensitive or damaging contractual issues</li>
+                                <li>sensitive diplomatic business or international trade negotiations</li>
+                                <li>sensitive personal information, such as grievance cases</li>
+                                <li>sensitive corporate information such as organisational restructuring, negotiations and major security or business continuity issues</li>
+                                <li>information relating to sensitive trade negotiations</li>
+                                <li>corporate information relating to contract negotiations and tender exercises</li>
+                                <li>company accounts</li>
+                                <li>procurement relating specifically to the security of DIT</li>
+                                <li>policy development and advice to ministers on contentious or sensitive issues</li>
+                            </ul>
+                        </p>
+                    </div>
+
+                    <div class="govuk-radios">
+                        {% for value, name in form.fields.is_summary_sensitive.choices %}
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="{{ form.is_summary_sensitive.name }}-{{ value }}" name="{{ form.is_summary_sensitive.name }}" type="radio" value="{{ value }}"{% if form.is_summary_sensitive.value == value %} checked="checked"{% endif %}>
+                                <label class="govuk-label govuk-radios__label" for="{{ form.is_summary_sensitive.name }}-{{ value }}">{{ name }}</label>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+
         <input type="submit" value="Save and exit to barrier" class="govuk-button">
     </form>
 

--- a/templates/barriers/edit/description.html
+++ b/templates/barriers/edit/description.html
@@ -32,19 +32,21 @@
                         {{ form.is_summary_sensitive.label }}
                     </legend>
 
-                    <a>What is OFFICIAL-SENSITIVE information?</a>
-
-                    <div class="govuk-inset-text">
-                        <p>The OFFICIAL classification is used for most Government business and public service delivery. OFFICIAL-SENSITIVE applies where loss or disclosure would:
-
-                            <ul>
+                    <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+                        <summary class="govuk-details__summary">
+                            <span class="govuk-details__summary-text">
+                              What is OFFICIAL-SENSITIVE information?
+                            </span>
+                        </summary>
+                        <div class="govuk-details__text">
+                            <p>The OFFICIAL classification is used for most Government business and public service delivery. OFFICIAL-SENSITIVE applies where loss or disclosure would:</p>
+                            <ul class="govuk-details__list">
                                 <li>have damaging consequences for DIT and the government</li>
                                 <li>cause significant distress for an individual or group of people, such as sensitive personal information</li>
                             </ul>
-                        </p>
 
-                        <p>OFFICIAL-SENSITIVE includes:
-                            <ul>
+                            <p>OFFICIAL-SENSITIVE includes:</p>
+                            <ul class="govuk-details__list">
                                 <li>sensitive or damaging contractual issues</li>
                                 <li>sensitive diplomatic business or international trade negotiations</li>
                                 <li>sensitive personal information, such as grievance cases</li>
@@ -55,8 +57,11 @@
                                 <li>procurement relating specifically to the security of DIT</li>
                                 <li>policy development and advice to ministers on contentious or sensitive issues</li>
                             </ul>
-                        </p>
-                    </div>
+
+                            <h4 class="govuk-details__heading">Further information</h4>
+                            <p>If you can access Digital Workspace please visit <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/information-classification-and-handling">Information classification and data handling</a>.</p>
+                        </div>
+                    </details>
 
                     <div class="govuk-radios">
                         {% for value, name in form.fields.is_summary_sensitive.choices %}
@@ -70,7 +75,8 @@
             </div>
         </div>
 
-        <input type="submit" value="Save and exit to barrier" class="govuk-button">
+        <input type="submit" value="Continue" class="govuk-button">
+        <a class="form-cancel" href="{% url 'barriers:barrier_detail' barrier.id %}">Cancel</a>
     </form>
 
 {% endblock %}

--- a/templates/barriers/edit/summary.html
+++ b/templates/barriers/edit/summary.html
@@ -14,12 +14,12 @@
     <form action="" method="POST" class="restrict-width">
         {% csrf_token %}
 
-        <div id="{{ form.description.name }}" class="govuk-form-group{% if form.description.errors %} govuk-form-group--error{% endif %}">
-            <label class="govuk-label govuk-label--s" for="description">{{ form.description.label }}</label>
+        <div id="{{ form.summary.name }}" class="govuk-form-group{% if form.summary.errors %} govuk-form-group--error{% endif %}">
+            <label class="govuk-label govuk-label--s" for="summary">{{ form.summary.label }}</label>
 
-            {% form_field_error form "description" %}
+            {% form_field_error form "summary" %}
 
-            <textarea class="govuk-textarea" name="description" rows="5">{% if form.description.value %}{{ form.description.value }}{% endif %}</textarea>
+            <textarea class="govuk-textarea" name="summary" rows="5">{% if form.summary.value %}{{ form.summary.value }}{% endif %}</textarea>
         </div>
 
         <div id="{{ form.is_summary_sensitive.name }}" class="govuk-form-group{% if form.is_summary_sensitive.errors %} govuk-form-group--error{% endif %}">

--- a/templates/barriers/edit/summary.html
+++ b/templates/barriers/edit/summary.html
@@ -75,7 +75,7 @@
             </div>
         </div>
 
-        <input type="submit" value="Continue" class="govuk-button">
+        <input type="submit" value="Save and exit to barrier" class="govuk-button">
         <a class="form-cancel" href="{% url 'barriers:barrier_detail' barrier.id %}">Cancel</a>
     </form>
 

--- a/templates/barriers/edit/summary.html
+++ b/templates/barriers/edit/summary.html
@@ -19,6 +19,20 @@
 
             {% form_field_error form "summary" %}
 
+            {% if barrier.is_summary_sensitive is not False %}
+                <div class="govuk-warning-text govuk-!-margin-bottom-4 govuk-!-margin-top-4">
+                    <span class="govuk-warning-text__icon govuk-warning-text__icon--small" aria-hidden="true">!</span>
+                    <strong class="govuk-warning-text__text govuk-warning-text__text--small">
+                        <span class="govuk-warning-text__assistive">Warning</span>
+                        {% if barrier.is_summary_sensitive is True %}
+                            This summary contains OFFICIAL-SENSITIVE information.
+                        {% else %}
+                            This summary has not been given a security classification.
+                        {% endif %}
+                    </strong>
+                </div>
+            {% endif %}
+
             <textarea class="govuk-textarea" name="summary" rows="5">{% if form.summary.value %}{{ form.summary.value }}{% endif %}</textarea>
         </div>
 

--- a/templates/barriers/edit/summary.html
+++ b/templates/barriers/edit/summary.html
@@ -32,36 +32,7 @@
                         {{ form.is_summary_sensitive.label }}
                     </legend>
 
-                    <details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
-                        <summary class="govuk-details__summary">
-                            <span class="govuk-details__summary-text">
-                              What is OFFICIAL-SENSITIVE information?
-                            </span>
-                        </summary>
-                        <div class="govuk-details__text">
-                            <p>The OFFICIAL classification is used for most Government business and public service delivery. OFFICIAL-SENSITIVE applies where loss or disclosure would:</p>
-                            <ul class="govuk-details__list">
-                                <li>have damaging consequences for DIT and the government</li>
-                                <li>cause significant distress for an individual or group of people, such as sensitive personal information</li>
-                            </ul>
-
-                            <p>OFFICIAL-SENSITIVE includes:</p>
-                            <ul class="govuk-details__list">
-                                <li>sensitive or damaging contractual issues</li>
-                                <li>sensitive diplomatic business or international trade negotiations</li>
-                                <li>sensitive personal information, such as grievance cases</li>
-                                <li>sensitive corporate information such as organisational restructuring, negotiations and major security or business continuity issues</li>
-                                <li>information relating to sensitive trade negotiations</li>
-                                <li>corporate information relating to contract negotiations and tender exercises</li>
-                                <li>company accounts</li>
-                                <li>procurement relating specifically to the security of DIT</li>
-                                <li>policy development and advice to ministers on contentious or sensitive issues</li>
-                            </ul>
-
-                            <h4 class="govuk-details__heading">Further information</h4>
-                            <p>If you can access Digital Workspace please visit <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/information-classification-and-handling">Information classification and data handling</a>.</p>
-                        </div>
-                    </details>
+                    {% include "partials/official_sensitive.html" %}
 
                     <div class="govuk-radios">
                         {% for value, name in form.fields.is_summary_sensitive.choices %}

--- a/templates/barriers/history/partials/barrier/is_summary_sensitive.html
+++ b/templates/barriers/history/partials/barrier/is_summary_sensitive.html
@@ -1,0 +1,9 @@
+{% if item.new_value is True %}
+    <div class="history-item__new-value">
+        Marked as including OFFICIAL-SENSITIVE information.
+    </div>
+{% elif item.new_value is False %}
+    <div class="history-item__new-value">
+        Marked as not including OFFICIAL-SENSITIVE information.
+    </div>
+{% endif %}

--- a/templates/barriers/history/partials/barrier/is_summary_sensitive.html
+++ b/templates/barriers/history/partials/barrier/is_summary_sensitive.html
@@ -1,9 +1,9 @@
 {% if item.new_value is True %}
     <div class="history-item__new-value">
-        Marked as including OFFICIAL-SENSITIVE information.
+        Marked as containing OFFICIAL-SENSITIVE information.
     </div>
 {% elif item.new_value is False %}
     <div class="history-item__new-value">
-        Marked as not including OFFICIAL-SENSITIVE information.
+        Marked as not containing OFFICIAL-SENSITIVE information.
     </div>
 {% endif %}

--- a/templates/partials/official_sensitive.html
+++ b/templates/partials/official_sensitive.html
@@ -1,0 +1,30 @@
+<details class="govuk-details govuk-!-margin-bottom-2" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          What is OFFICIAL-SENSITIVE information?
+        </span>
+    </summary>
+    <div class="govuk-details__text">
+        <p>The OFFICIAL classification is used for most Government business and public service delivery. OFFICIAL-SENSITIVE applies where loss or disclosure would:</p>
+        <ul class="govuk-details__list">
+            <li>have damaging consequences for DIT and the government</li>
+            <li>cause significant distress for an individual or group of people, such as sensitive personal information</li>
+        </ul>
+
+        <p>OFFICIAL-SENSITIVE includes:</p>
+        <ul class="govuk-details__list">
+            <li>sensitive or damaging contractual issues</li>
+            <li>sensitive diplomatic business or international trade negotiations</li>
+            <li>sensitive personal information, such as grievance cases</li>
+            <li>sensitive corporate information such as organisational restructuring, negotiations and major security or business continuity issues</li>
+            <li>information relating to sensitive trade negotiations</li>
+            <li>corporate information relating to contract negotiations and tender exercises</li>
+            <li>company accounts</li>
+            <li>procurement relating specifically to the security of DIT</li>
+            <li>policy development and advice to ministers on contentious or sensitive issues</li>
+        </ul>
+
+        <h4 class="govuk-details__heading">Further information</h4>
+        <p>If you can access Digital Workspace please visit <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/information-classification-and-handling">Information classification and data handling</a>.</p>
+    </div>
+</details>

--- a/templates/reports/new_report_barrier_summary.html
+++ b/templates/reports/new_report_barrier_summary.html
@@ -14,18 +14,18 @@
             {% csrf_token %}
 
             <div class="govuk-character-count" data-module="character-count" data-maxlength="300">
-                <div class="{% form_group_classes form.problem_description.errors %}">
+                <div class="{% form_group_classes form.summary.errors %}">
                     <label class="govuk-label govuk-label--s" for="description">
-                        {{ form.problem_description.label }}
+                        {{ form.summary.label }}
                     </label>
-                    {% form_field_error form "problem_description" %}
+                    {% form_field_error form "summary" %}
                     <span id="description-hint" class="govuk-hint">
-                        {{ form.problem_description.help_text }}
+                        {{ form.summary.help_text }}
                     </span>
                     <textarea class="govuk-textarea js-character-count" id="description"
-                              name="{{ form.problem_description.name }}"
+                              name="{{ form.summary.name }}"
                               rows="5"
-                              aria-describedby="description-hint description-info">{{ form.initial.problem_description }}</textarea>
+                              aria-describedby="description-hint description-info">{{ form.initial.summary }}</textarea>
                 </div>
             </div>
             {% if not is_resolved %}

--- a/templates/reports/new_report_barrier_summary.html
+++ b/templates/reports/new_report_barrier_summary.html
@@ -29,28 +29,26 @@
                 </div>
             </div>
 
-            <div id="{{ form.is_summary_sensitive.name }}" class="govuk-form-group{% if form.is_summary_sensitive.errors %} govuk-form-group--error{% endif %}">
+            <div id="{{ form.is_summary_sensitive.name }}" class="{% form_group_classes form.is_summary_sensitive.errors %}">
 
                 {% form_field_error form "is_summary_sensitive" %}
 
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
-                            {{ form.is_summary_sensitive.label }}
-                        </legend>
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                        {{ form.is_summary_sensitive.label }}
+                    </legend>
 
-                        {% include "partials/official_sensitive.html" %}
+                    {% include "partials/official_sensitive.html" %}
 
-                        <div class="govuk-radios">
-                            {% for value, name in form.fields.is_summary_sensitive.choices %}
-                                <div class="govuk-radios__item">
-                                    <input class="govuk-radios__input" id="{{ form.is_summary_sensitive.name }}-{{ value }}" name="{{ form.is_summary_sensitive.name }}" type="radio" value="{{ value }}"{% if form.is_summary_sensitive.value == value %} checked="checked"{% endif %}>
-                                    <label class="govuk-label govuk-radios__label" for="{{ form.is_summary_sensitive.name }}-{{ value }}">{{ name }}</label>
-                                </div>
-                            {% endfor %}
-                        </div>
-                    </fieldset>
-                </div>
+                    <div class="govuk-radios">
+                        {% for value, name in form.fields.is_summary_sensitive.choices %}
+                            <div class="govuk-radios__item">
+                                <input class="govuk-radios__input" id="{{ form.is_summary_sensitive.name }}-{{ value }}" name="{{ form.is_summary_sensitive.name }}" type="radio" value="{{ value }}"{% if form.is_summary_sensitive.value == value %} checked="checked"{% endif %}>
+                                <label class="govuk-label govuk-radios__label" for="{{ form.is_summary_sensitive.name }}-{{ value }}">{{ name }}</label>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </fieldset>
             </div>
 
             {% if not is_resolved %}

--- a/templates/reports/new_report_barrier_summary.html
+++ b/templates/reports/new_report_barrier_summary.html
@@ -28,6 +28,31 @@
                               aria-describedby="description-hint description-info">{{ form.initial.summary }}</textarea>
                 </div>
             </div>
+
+            <div id="{{ form.is_summary_sensitive.name }}" class="govuk-form-group{% if form.is_summary_sensitive.errors %} govuk-form-group--error{% endif %}">
+
+                {% form_field_error form "is_summary_sensitive" %}
+
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">
+                            {{ form.is_summary_sensitive.label }}
+                        </legend>
+
+                        {% include "partials/official_sensitive.html" %}
+
+                        <div class="govuk-radios">
+                            {% for value, name in form.fields.is_summary_sensitive.choices %}
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="{{ form.is_summary_sensitive.name }}-{{ value }}" name="{{ form.is_summary_sensitive.name }}" type="radio" value="{{ value }}"{% if form.is_summary_sensitive.value == value %} checked="checked"{% endif %}>
+                                    <label class="govuk-label govuk-radios__label" for="{{ form.is_summary_sensitive.name }}-{{ value }}">{{ name }}</label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    </fieldset>
+                </div>
+            </div>
+
             {% if not is_resolved %}
             <div class="{% form_group_classes form.next_steps_summary.errors %}">
                 <label class="govuk-label govuk-label--s" for="next-steps">

--- a/tests/barriers/fixtures/barriers.json
+++ b/tests/barriers/fixtures/barriers.json
@@ -18,7 +18,7 @@
         "source": "GOVT",
         "other_source": null,
         "barrier_title": "Import quota for sports cars",
-        "problem_description": "Because of laws for pollution reduction, which Parlament imposed under pressure from EU, they are limiting the imports of sports cars.",
+        "summary": "Because of laws for pollution reduction, which Parlament imposed under pressure from EU, they are limiting the imports of sports cars.",
         "is_summary_sensitive": false,
         "barrier_types": [115, 141],
         "reported_on": "2019-10-28T11:45:44.720000Z",

--- a/tests/barriers/fixtures/barriers.json
+++ b/tests/barriers/fixtures/barriers.json
@@ -19,6 +19,7 @@
         "other_source": null,
         "barrier_title": "Import quota for sports cars",
         "problem_description": "Because of laws for pollution reduction, which Parlament imposed under pressure from EU, they are limiting the imports of sports cars.",
+        "is_summary_sensitive": false,
         "barrier_types": [115, 141],
         "reported_on": "2019-10-28T11:45:44.720000Z",
         "reported_by": "Boris Karaberberov",
@@ -67,6 +68,7 @@
             "name": "Unknown",
             "order": 0
         },
+        "is_summary_sensitive": false,
         "barrier_types": [111, 115, 130, 141],
         "created_on": "2019-11-14T18:32:34.384000Z",
         "modified_on": "2020-01-23T09:21:25.371626Z"
@@ -96,6 +98,7 @@
             "name": "Unknown",
             "order": 0
         },
+        "is_summary_sensitive": false,
         "barrier_types": [129],
         "created_on": "2019-03-20T15:25:59.033000Z",
         "modified_on": "2019-04-10T11:33:09.851000Z"
@@ -125,6 +128,7 @@
             "name": "Unknown",
             "order": 0
         },
+        "is_summary_sensitive": false,
         "barrier_types": [],
         "created_on": "2019-06-19T15:17:23.776000Z",
         "modified_on": "2019-07-24T18:29:37.083000Z"

--- a/tests/barriers/test_edit_barrier_fields.py
+++ b/tests/barriers/test_edit_barrier_fields.py
@@ -52,7 +52,7 @@ class EditSummaryTestCase(MarketAccessTestCase):
         assert response.status_code == HTTPStatus.OK
         assert "form" in response.context
         form = response.context["form"]
-        assert form.initial["summary"] == self.barrier["problem_description"]
+        assert form.initial["summary"] == self.barrier["summary"]
 
     @patch("utils.api.resources.APIResource.patch")
     def test_summary_cannot_be_empty(self, mock_patch):
@@ -82,7 +82,7 @@ class EditSummaryTestCase(MarketAccessTestCase):
         )
         mock_patch.assert_called_with(
             id=self.barrier["id"],
-            problem_description="New summary",
+            summary="New summary",
             is_summary_sensitive=True,
         )
         assert response.status_code == HTTPStatus.FOUND

--- a/tests/barriers/test_edit_barrier_fields.py
+++ b/tests/barriers/test_edit_barrier_fields.py
@@ -69,6 +69,20 @@ class EditSummaryTestCase(MarketAccessTestCase):
         assert mock_patch.called is False
 
     @patch("utils.api.resources.APIResource.patch")
+    def test_is_summary_sensitive_is_required(self, mock_patch):
+        response = self.client.post(
+            reverse(
+                "barriers:edit_summary", kwargs={"barrier_id": self.barrier["id"]}
+            ),
+            data={"summary": "This is a summary"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        form = response.context["form"]
+        assert form.is_valid() is False
+        assert "is_summary_sensitive" in form.errors
+        assert mock_patch.called is False
+
+    @patch("utils.api.resources.APIResource.patch")
     def test_edit_summary_calls_api(self, mock_patch):
         mock_patch.return_value = self.barrier
         response = self.client.post(

--- a/tests/barriers/test_edit_barrier_fields.py
+++ b/tests/barriers/test_edit_barrier_fields.py
@@ -42,43 +42,48 @@ class EditTitleTestCase(MarketAccessTestCase):
         assert response.status_code == HTTPStatus.FOUND
 
 
-class EditDescriptionTestCase(MarketAccessTestCase):
-    def test_edit_description_has_initial_data(self):
+class EditSummaryTestCase(MarketAccessTestCase):
+    def test_edit_summary_has_initial_data(self):
         response = self.client.get(
             reverse(
-                "barriers:edit_description", kwargs={"barrier_id": self.barrier["id"]}
+                "barriers:edit_summary", kwargs={"barrier_id": self.barrier["id"]}
             )
         )
         assert response.status_code == HTTPStatus.OK
         assert "form" in response.context
         form = response.context["form"]
-        assert form.initial["description"] == self.barrier["problem_description"]
+        assert form.initial["summary"] == self.barrier["problem_description"]
 
     @patch("utils.api.resources.APIResource.patch")
-    def test_description_cannot_be_empty(self, mock_patch):
+    def test_summary_cannot_be_empty(self, mock_patch):
         response = self.client.post(
             reverse(
-                "barriers:edit_description", kwargs={"barrier_id": self.barrier["id"]}
+                "barriers:edit_summary", kwargs={"barrier_id": self.barrier["id"]}
             ),
-            data={"description": ""},
+            data={"summary": ""},
         )
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
         assert form.is_valid() is False
-        assert "description" in form.errors
+        assert "summary" in form.errors
         assert mock_patch.called is False
 
     @patch("utils.api.resources.APIResource.patch")
-    def test_edit_description_calls_api(self, mock_patch):
+    def test_edit_summary_calls_api(self, mock_patch):
         mock_patch.return_value = self.barrier
         response = self.client.post(
             reverse(
-                "barriers:edit_description", kwargs={"barrier_id": self.barrier["id"]}
+                "barriers:edit_summary", kwargs={"barrier_id": self.barrier["id"]}
             ),
-            data={"description": "New description"},
+            data={
+                "summary": "New summary",
+                "is_summary_sensitive": "yes",
+            },
         )
         mock_patch.assert_called_with(
-            id=self.barrier["id"], problem_description="New description",
+            id=self.barrier["id"],
+            problem_description="New summary",
+            is_summary_sensitive=True,
         )
         assert response.status_code == HTTPStatus.FOUND
 

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -69,20 +69,20 @@ class BarrierHistoryItemTestCase(MarketAccessTestCase):
         assert item.old_value == ["Mercury Ltd"]
         assert item.new_value == []
 
-    def test_description(self):
+    def test_summary(self):
         item = HistoryItem(
             {
                 "date": "2019-08-15T09:54:05.222000Z",
                 "model": "barrier",
                 "field": "problem_description",
-                "old_value": "Old description",
-                "new_value": "New description",
+                "old_value": "Old summary",
+                "new_value": "New summary",
                 "user": {"id": 48, "name": "Test-user"},
             }
         )
         assert item.field_name == "Summary"
-        assert item.old_value == "Old description"
-        assert item.new_value == "New description"
+        assert item.old_value == "Old summary"
+        assert item.new_value == "New summary"
 
     def test_location(self):
         item = HistoryItem(

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -74,7 +74,7 @@ class BarrierHistoryItemTestCase(MarketAccessTestCase):
             {
                 "date": "2019-08-15T09:54:05.222000Z",
                 "model": "barrier",
-                "field": "problem_description",
+                "field": "summary",
                 "old_value": "Old summary",
                 "new_value": "New summary",
                 "user": {"id": 48, "name": "Test-user"},

--- a/tests/reports/fixtures/draft_barriers.json
+++ b/tests/reports/fixtures/draft_barriers.json
@@ -19,7 +19,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
       {
@@ -81,7 +81,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -143,7 +143,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -205,7 +205,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -267,7 +267,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -331,7 +331,7 @@
     "source": null,
     "other_source": null,
     "barrier_title": null,
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -395,7 +395,7 @@
     "source": "COMPANY",
     "other_source": null,
     "barrier_title": "wibble",
-    "problem_description": null,
+    "summary": null,
     "next_steps_summary": null,
     "progress": [
         {
@@ -459,7 +459,7 @@
     "source": "COMPANY",
     "other_source": null,
     "barrier_title": "wibble",
-    "problem_description": "wibble",
+    "summary": "wibble",
     "next_steps_summary": "wobble",
     "progress": [
         {

--- a/tests/reports/test_summary_views.py
+++ b/tests/reports/test_summary_views.py
@@ -63,6 +63,13 @@ class SummaryViewTestCase(ReportsTestCase):
             "Enter a brief description for this barrier",
         )
 
+        self.assertFormError(
+            response,
+            "form",
+            "is_summary_sensitive",
+            "Indicate if summary contains OFFICIAL-SENSITIVE information or not",
+        )
+
         assert ERROR_HTML.SUMMARY_HEADER in html
         assert ERROR_HTML.REQUIRED_FIELD in html
         assert saved_form_data is None
@@ -81,6 +88,7 @@ class SummaryViewTestCase(ReportsTestCase):
         redirect_url = reverse("barriers:barrier_detail", kwargs={"barrier_id": self.draft["id"]})
         data = {
             "summary": "wibble wobble",
+            "is_summary_sensitive": "no",
             "next_steps_summary": "step 1 - wobble, step 2 - wibble",
         }
 
@@ -104,6 +112,7 @@ class SummaryViewTestCase(ReportsTestCase):
         data = {
             "action": "exit",
             "summary": "wibble wobble",
+            "is_summary_sensitive": "no",
             "next_steps_summary": "step 1 - wobble, step 2 - wibble",
         }
 

--- a/tests/reports/test_summary_views.py
+++ b/tests/reports/test_summary_views.py
@@ -59,7 +59,7 @@ class SummaryViewTestCase(ReportsTestCase):
         self.assertFormError(
             response,
             "form",
-            "problem_description",
+            "summary",
             "Enter a brief description for this barrier",
         )
 
@@ -80,7 +80,7 @@ class SummaryViewTestCase(ReportsTestCase):
         mock_get.return_value = Report(self.draft)
         redirect_url = reverse("barriers:barrier_detail", kwargs={"barrier_id": self.draft["id"]})
         data = {
-            "problem_description": "wibble wobble",
+            "summary": "wibble wobble",
             "next_steps_summary": "step 1 - wobble, step 2 - wibble",
         }
 
@@ -103,7 +103,7 @@ class SummaryViewTestCase(ReportsTestCase):
         redirect_url = reverse("reports:draft_barrier_details_uuid", kwargs={"barrier_id": self.draft["id"]})
         data = {
             "action": "exit",
-            "problem_description": "wibble wobble",
+            "summary": "wibble wobble",
             "next_steps_summary": "step 1 - wobble, step 2 - wibble",
         }
 

--- a/ui_tests/helpers/barriers.py
+++ b/ui_tests/helpers/barriers.py
@@ -55,7 +55,7 @@ def create_barrier(browser):
     browser.choose("source", "COMPANY")
     browser.find_by_css("input[type=submit]").click()
 
-    browser.fill("problem_description", "Test description")
+    browser.fill("summary", "Test description")
     browser.fill("next_steps_summary", "Test note")
     browser.find_by_css("input[type=submit]").click()
 

--- a/ui_tests/test_add_a_barrier.py
+++ b/ui_tests/test_add_a_barrier.py
@@ -93,7 +93,7 @@ def test_continue_draft_barrier(browser):
     browser.choose("source", "COMPANY")
     browser.find_by_css("input[type=submit]").click()
 
-    browser.fill("problem_description", "Test description")
+    browser.fill("summary", "Test description")
     browser.fill("next_steps_summary", "Test next steps")
     browser.find_by_css('button[value="exit"]').click()
 

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -159,6 +159,7 @@ class YesNoBooleanField(forms.ChoiceField):
             return "yes"
         elif data is False:
             return "no"
+        return data
 
     def to_python(self, value):
         if value == "yes":

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -142,6 +142,35 @@ class MonthYearWidget(forms.MultiWidget):
         return super().value_from_datadict(data, files, name)
 
 
+class YesNoBooleanField(forms.ChoiceField):
+    """
+    Display a BooleanField as Yes and No radio buttons
+    """
+
+    def __init__(self, **kwargs):
+        choices = (
+            ("yes", "Yes"),
+            ("no", "No"),
+        )
+        super().__init__(choices=choices, **kwargs)
+
+    def prepare_value(self, data):
+        if data is True:
+            return "yes"
+        elif data is False:
+            return "no"
+
+    def to_python(self, value):
+        if value == "yes":
+            return True
+        elif value == "no":
+            return False
+
+    def valid_value(self, value):
+        value = self.prepare_value(value)
+        return super().valid_value(value)
+
+
 class MonthYearField(forms.MultiValueField):
     widget = MonthYearWidget
     default_validators = [validate_date_not_in_future]


### PR DESCRIPTION
* Rename `description` and `problem_description` to `summary` for better consistency.
* Add `is_summary_sensitive` field to summary forms (for both editing and reporting).
* Add changes to `is_summary_sensitive` to the history tab.
* Update govuk warning css file to latest version.