### PR TITLE
MAR-402 - persist tag selection on invalid form

### DIFF
--- a/core/fixtures/metadata.json
+++ b/core/fixtures/metadata.json
@@ -7666,14 +7666,14 @@
             "id": 1,
             "title": "COVID-19",
             "description": "Barrier imposed because of the COVID-19 (coronavirus) pandemic. For example restrictions related to medical supplies or food supply chains.",
-            "show_at_reporting": "True",
+            "show_at_reporting": true,
             "order": 1
         },
         {
             "id": 2,
             "title": "Brexit",
             "description": "",
-            "show_at_reporting": "True",
+            "show_at_reporting": true,
             "order": 2
         }
     ],

--- a/templates/reports/new_report_barrier_about.html
+++ b/templates/reports/new_report_barrier_about.html
@@ -88,7 +88,10 @@
                     <div class="govuk-checkboxes" id="tags">
                         {% for value, name, help_text in form.fields.tags.choices %}
                             <div class="govuk-checkboxes__item">
-                                <input class="govuk-checkboxes__input" id="tag-{{ value }}" name="{{ form.tags.name }}" type="checkbox" value="{{ value }}"  {% if value in form.tags.value %}checked="checked"{% endif %}>
+                                <input class="govuk-checkboxes__input"
+                                       id="tag-{{ value }}"
+                                       name="{{ form.tags.name }}"
+                                       type="checkbox" value="{{ value }}"{% if value|lower in form.tags.value %} checked="checked"{% endif %}>
                                 <label class="govuk-label govuk-checkboxes__label" for="tag-{{ value }}">{{ name }}</label>
                                 <span id="nationality-item-hint" class="govuk-hint govuk-checkboxes__hint">
                                   {{ help_text }}

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -340,7 +340,7 @@ class Metadata:
         return (
             (tag["id"], tag["title"], tag["description"])
             for tag in self.get_barrier_tags()
-            if tag["show_at_reporting"] in (True, "True")
+            if tag["show_at_reporting"] is True
         )
 
     def get_trade_direction(self, key=None, all_items=False):

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -340,7 +340,7 @@ class Metadata:
         return (
             (tag["id"], tag["title"], tag["description"])
             for tag in self.get_barrier_tags()
-            if tag["show_at_reporting"] is True
+            if tag["show_at_reporting"] in (True, "True")
         )
 
     def get_trade_direction(self, key=None, all_items=False):


### PR DESCRIPTION
MAR-402:
 - allow tags to load when metadata is mocked
 - convert int to str so it can be matched to the list items