### PR TITLE
MAR-247: Add correlation ids to logging

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -244,28 +244,6 @@ API_RESULTS_LIMIT = env.int('API_RESULTS_LIMIT', default=100)
 # Logging
 # ============================================
 DJANGO_LOG_LEVEL = env("DJANGO_LOG_LEVEL", default="info").upper()
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-            "format": "(asctime)(levelname)(message)(filename)(lineno)(threadName)(name)(thread)(created)(process)(processName)(relativeCreated)(module)(funcName)(levelno)(msecs)(pathname)",  # noqa
-        }
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "json"
-        }
-    },
-    "loggers": {
-        "": {
-            "handlers": ["console"],
-            "level": DJANGO_LOG_LEVEL
-        }
-    },
-}
 
 
 # Google Tag Manager

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,14 +11,11 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
-import sys
 
 from environ import Env
 from pathlib import Path
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
-
-from django_log_formatter_ecs import ECSFormatter
 
 
 ROOT_DIR = Path(__file__).parents[2]
@@ -251,20 +248,20 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "ecs_formatter": {
-            "()": ECSFormatter,
-        },
+        "json": {
+            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
+            "format": "(asctime)(levelname)(message)(filename)(lineno)(threadName)(name)(thread)(created)(process)(processName)(relativeCreated)(module)(funcName)(levelno)(msecs)(pathname)",  # noqa
+        }
     },
     "handlers": {
-        "ecs": {
-            "formatter": "ecs_formatter",
+        "console": {
             "class": "logging.StreamHandler",
-            "stream": sys.stdout,
-        },
+            "formatter": "json"
+        }
     },
     "loggers": {
         "": {
-            "handlers": ["ecs"],
+            "handlers": ["console"],
             "level": DJANGO_LOG_LEVEL
         }
     },

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,11 +11,14 @@ https://docs.djangoproject.com/en/3.0/ref/settings/
 """
 
 import os
+import sys
 
 from environ import Env
 from pathlib import Path
 import sentry_sdk
 from sentry_sdk.integrations.django import DjangoIntegration
+
+from django_log_formatter_ecs import ECSFormatter
 
 
 ROOT_DIR = Path(__file__).parents[2]
@@ -248,20 +251,20 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "json": {
-            "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-            "format": "(asctime)(levelname)(message)(filename)(lineno)(threadName)(name)(thread)(created)(process)(processName)(relativeCreated)(module)(funcName)(levelno)(msecs)(pathname)",  # noqa
-        }
+        "ecs_formatter": {
+            "()": ECSFormatter,
+        },
     },
     "handlers": {
-        "console": {
+        "ecs": {
+            "formatter": "ecs_formatter",
             "class": "logging.StreamHandler",
-            "formatter": "json"
-        }
+            "stream": sys.stdout,
+        },
     },
     "loggers": {
         "": {
-            "handlers": ["console"],
+            "handlers": ["ecs"],
             "level": DJANGO_LOG_LEVEL
         }
     },

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,3 +1,30 @@
+import sys
 from .base import *                 # noqa
 
+from django_log_formatter_ecs import ECSFormatter
+
 DJANGO_ENV = 'dev'
+
+# Unable to put this in base.py because of circular import problem with ECSFormatter
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "ecs_formatter": {
+            "()": ECSFormatter,
+        },
+    },
+    "handlers": {
+        "ecs": {
+            "formatter": "ecs_formatter",
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["ecs"],
+            "level": DJANGO_LOG_LEVEL
+        }
+    },
+}

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,3 +1,32 @@
+import sys
 from .base import *                 # noqa
 
+from django_log_formatter_ecs import ECSFormatter
+
+
 DJANGO_ENV = 'dev'
+
+DJANGO_LOG_LEVEL = env("DJANGO_LOG_LEVEL", default="info").upper()
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "ecs_formatter": {
+            "()": ECSFormatter,
+        },
+    },
+    "handlers": {
+        "ecs": {
+            "formatter": "ecs_formatter",
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["ecs"],
+            "level": DJANGO_LOG_LEVEL
+        }
+    },
+}

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,32 +1,3 @@
-import sys
 from .base import *                 # noqa
 
-from django_log_formatter_ecs import ECSFormatter
-
-
 DJANGO_ENV = 'dev'
-
-DJANGO_LOG_LEVEL = env("DJANGO_LOG_LEVEL", default="info").upper()
-
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "ecs_formatter": {
-            "()": ECSFormatter,
-        },
-    },
-    "handlers": {
-        "ecs": {
-            "formatter": "ecs_formatter",
-            "class": "logging.StreamHandler",
-            "stream": sys.stdout,
-        },
-    },
-    "loggers": {
-        "": {
-            "handlers": ["ecs"],
-            "level": DJANGO_LOG_LEVEL
-        }
-    },
-}

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -1,4 +1,32 @@
+import sys
 from .base import *                 # noqa
 
+from django_log_formatter_ecs import ECSFormatter
+
+
 DJANGO_ENV = 'prod'
+
 DEBUG = False
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "ecs_formatter": {
+            "()": ECSFormatter,
+        },
+    },
+    "handlers": {
+        "ecs": {
+            "formatter": "ecs_formatter",
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["ecs"],
+            "level": DJANGO_LOG_LEVEL
+        }
+    },
+}

--- a/config/settings/prod.py
+++ b/config/settings/prod.py
@@ -8,6 +8,7 @@ DJANGO_ENV = 'prod'
 
 DEBUG = False
 
+# Unable to put this in base.py because of circular import problem with ECSFormatter
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/config/settings/uat.py
+++ b/config/settings/uat.py
@@ -1,3 +1,30 @@
+import sys
 from .base import *                 # noqa
 
+from django_log_formatter_ecs import ECSFormatter
+
 DJANGO_ENV = 'uat'
+
+# Unable to put this in base.py because of circular import problem with ECSFormatter
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "ecs_formatter": {
+            "()": ECSFormatter,
+        },
+    },
+    "handlers": {
+        "ecs": {
+            "formatter": "ecs_formatter",
+            "class": "logging.StreamHandler",
+            "stream": sys.stdout,
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["ecs"],
+            "level": DJANGO_LOG_LEVEL
+        }
+    },
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -193,6 +193,26 @@ six = ">=1.2"
 
 [[package]]
 category = "main"
+description = "A Django utility application that returns client's real IP address"
+name = "django-ipware"
+optional = false
+python-versions = "*"
+version = "2.1.0"
+
+[[package]]
+category = "main"
+description = "ECS log formatter for Django"
+name = "django-log-formatter-ecs"
+optional = false
+python-versions = ">=3.6"
+version = "0.0.2"
+
+[package.dependencies]
+django-ipware = ">=2.1.0"
+kubi-ecs-logger = ">=0.0.6"
+
+[[package]]
+category = "main"
 description = "Django model mixins and utilities"
 name = "django-model-utils"
 optional = false
@@ -390,6 +410,31 @@ parso = ">=0.7.0"
 [package.extras]
 qa = ["flake8 (3.7.9)"]
 testing = ["colorama", "docopt", "pytest (>=3.9.0,<5.0.0)"]
+
+[[package]]
+category = "main"
+description = "Logger based on Elasticsearch Common Schema."
+name = "kubi-ecs-logger"
+optional = false
+python-versions = ">=3.6, <4"
+version = "0.0.6"
+
+[package.dependencies]
+marshmallow = "2.19.2"
+
+[[package]]
+category = "main"
+description = "A lightweight library for converting complex datatypes to and from native Python datatypes."
+name = "marshmallow"
+optional = false
+python-versions = "*"
+version = "2.19.2"
+
+[package.extras]
+dev = ["python-dateutil", "simplejson", "pytest", "pytz", "flake8 (3.7.4)", "tox"]
+lint = ["flake8 (3.7.4)"]
+reco = ["python-dateutil", "simplejson"]
+tests = ["pytest", "pytz"]
 
 [[package]]
 category = "dev"
@@ -938,7 +983,7 @@ test = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 
 [metadata]
-content-hash = "91de554457c416ebe760e409e686265e5b39ad634a33623f9813cc2f9a672980"
+content-hash = "3bbb79b4852a8f6c8c48960134092d32c4871d76ad1104a82f2e4a66dadc51e4"
 python-versions = "^3.7"
 
 [metadata.files]
@@ -1086,6 +1131,13 @@ django-extensions = [
     {file = "django-extensions-2.2.9.tar.gz", hash = "sha256:2f81b618ba4d1b0e58603e25012e5c74f88a4b706e0022a3b21f24f0322a6ce6"},
     {file = "django_extensions-2.2.9-py2.py3-none-any.whl", hash = "sha256:b19182d101a441fe001c5753553a901e2ef3ff60e8fbbe38881eb4a61fdd17c4"},
 ]
+django-ipware = [
+    {file = "django-ipware-2.1.0.tar.gz", hash = "sha256:a7c7a8fd019dbdc9c357e6e582f65034e897572fc79a7e467674efa8aef9d00b"},
+]
+django-log-formatter-ecs = [
+    {file = "django_log_formatter_ecs-0.0.2-py3-none-any.whl", hash = "sha256:4052d492c4972a97ccc18aa832cc84e0514fde6560de422b21d8b0c99fe01c5f"},
+    {file = "django_log_formatter_ecs-0.0.2.tar.gz", hash = "sha256:22cbc12fbb0aa8b5be99b18b732601c6fa26e9c28edb14c62e1b35fb2dbc0730"},
+]
 django-model-utils = [
     {file = "django-model-utils-4.0.0.tar.gz", hash = "sha256:adf09e5be15122a7f4e372cb5a6dd512bbf8d78a23a90770ad0983ee9d909061"},
     {file = "django_model_utils-4.0.0-py2.py3-none-any.whl", hash = "sha256:9cf882e5b604421b62dbe57ad2b18464dc9c8f963fc3f9831badccae66c1139c"},
@@ -1201,6 +1253,13 @@ ipython-genutils = [
 jedi = [
     {file = "jedi-0.17.0-py2.py3-none-any.whl", hash = "sha256:cd60c93b71944d628ccac47df9a60fec53150de53d42dc10a7fc4b5ba6aae798"},
     {file = "jedi-0.17.0.tar.gz", hash = "sha256:df40c97641cb943661d2db4c33c2e1ff75d491189423249e989bcea4464f3030"},
+]
+kubi-ecs-logger = [
+    {file = "kubi_ecs_logger-0.0.6.tar.gz", hash = "sha256:65ffd11860e06c0c68e17a508f37d76b28780dc8b4811ffc4316aae75375f673"},
+]
+marshmallow = [
+    {file = "marshmallow-2.19.2-py2.py3-none-any.whl", hash = "sha256:0e497a6447ffaad55578138ca512752de7a48d12f444996ededc3d6bf8a09ca2"},
+    {file = "marshmallow-2.19.2.tar.gz", hash = "sha256:e21a4dea20deb167c723e0ffb13f4cf33bcbbeb8a334e92406a3308cedea2826"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ redis = "==3.5.2"
 requests = "==2.23.0"
 sentry-sdk = "==0.14.4"
 whitenoise = "==5.1.0"
+django-log-formatter-ecs = "==0.0.2"
 
 [tool.poetry.dev-dependencies]
 black = "~=19.10b0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # ======
 # DO NOT EDIT - use pyproject.toml instead!
-# Generated: 2020-06-04_10-37
+# Generated: 2020-06-04_14-45
 # ======
 certifi==2020.4.5.1
 cffi==1.14.0
@@ -8,6 +8,8 @@ chardet==3.0.4
 django==2.2.13
 django-environ==0.4.5
 django-extensions==2.2.9
+django-ipware==2.1.0
+django-log-formatter-ecs==0.0.2
 django-model-utils==4.0.0
 django-settings-export==1.2.1
 elastic-apm==5.6.0
@@ -15,6 +17,8 @@ gevent==20.5.2
 greenlet==0.4.15; platform_python_implementation == "CPython"
 gunicorn==20.0.4
 idna==2.9
+kubi-ecs-logger==0.0.6
+marshmallow==2.19.2
 mohawk==1.1.0
 psycopg2-binary==2.8.5
 pycparser==2.20; platform_python_implementation == "CPython" and sys_platform == "win32"


### PR DESCRIPTION
Use `django_log_formatter_ecs` to add correlation ids to logs