### PR TITLE
MAR-519: Status history

### DIFF
--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -133,8 +133,8 @@ class PublicEligibilitySummaryHistoryItem(BaseHistoryItem):
     modifier = "note"
 
 
-class ScopeHistoryItem(BaseHistoryItem):
-    field = "term"
+class TermHistoryItem(BaseHistoryItem):
+    field = "problem_status"
     field_name = "Type"
 
     def get_value(self, value):
@@ -242,12 +242,12 @@ class BarrierHistoryItem(PolymorphicBase):
         ProductHistoryItem,
         PriorityHistoryItem,
         PublicEligibilitySummaryHistoryItem,
-        ScopeHistoryItem,
         SectorsHistoryItem,
         SourceHistoryItem,
         StatusHistoryItem,
         SummaryHistoryItem,
         TagsHistoryItem,
+        TermHistoryItem,
         TitleHistoryItem,
         TradeDirectionHistoryItem,
     )

--- a/barriers/models/history/base.py
+++ b/barriers/models/history/base.py
@@ -36,7 +36,7 @@ class BaseHistoryItem(APIModel):
     @property
     def diff(self):
         dmp = diff_match_patch()
-        diffs = dmp.diff_main(self.old_value, self.new_value)
+        diffs = dmp.diff_main(self.old_value or "", self.new_value or "")
         dmp.diff_cleanupSemantic(diffs)
         return dmp.diff_prettyHtml(diffs)
 

--- a/tests/barriers/test_history.py
+++ b/tests/barriers/test_history.py
@@ -150,12 +150,12 @@ class BarrierHistoryItemTestCase(MarketAccessTestCase):
         assert item.old_value is None
         assert item.new_value == "Product Name"
 
-    def test_scope(self):
+    def test_term(self):
         item = HistoryItem(
             {
                 "date": "2020-03-19T15:03:03.599763Z",
                 "model": "barrier",
-                "field": "term",
+                "field": "problem_status",
                 "old_value": 1,
                 "new_value": 2,
                 "user": {"id": 48, "name": "Test-user"},


### PR DESCRIPTION
* Fix 'term' history (history items use the db field name rather than the serializer name)
* Ensure text diffs don't fail if value is None