### PR TITLE
MAR-564: Commodities can now be associated to a trading bloc

### DIFF
--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -59,8 +59,13 @@ class Barrier(APIModel):
     def commodities_grouped_by_country(self):
         grouped_commodities = {}
         for barrier_commodity in self.commodities:
-            grouped_commodities.setdefault(barrier_commodity.country["id"], [])
-            grouped_commodities[barrier_commodity.country["id"]].append(barrier_commodity)
+            if barrier_commodity.country:
+                key = barrier_commodity.country["id"]
+            elif barrier_commodity.trading_bloc:
+                key = barrier_commodity.trading_bloc["code"]
+
+            grouped_commodities.setdefault(key, [])
+            grouped_commodities[key].append(barrier_commodity)
         return grouped_commodities
 
     @property

--- a/barriers/models/commodities.py
+++ b/barriers/models/commodities.py
@@ -1,3 +1,4 @@
+from utils.metadata import get_metadata
 from utils.models import APIModel
 
 
@@ -15,11 +16,20 @@ class Commodity(APIModel):
     """
     A commodity containing a code and description
     """
-    def create_barrier_commodity(self, code, country_id):
+    def create_barrier_commodity(self, code, location):
+        metadata = get_metadata()
+        if metadata.is_trading_bloc_code(location):
+            return BarrierCommodity({
+                "commodity": self.data,
+                "code": code,
+                "country": None,
+                "trading_bloc": {"code": location},
+            })
         return BarrierCommodity({
             "commodity": self.data,
             "code": code,
-            "country": {"id": country_id},
+            "country": {"id": location},
+            "trading_bloc": None,
         })
 
     @property
@@ -56,5 +66,6 @@ class BarrierCommodity(APIModel):
             "code": self.code,
             "code_display": self.code_display,
             "country": self.country,
+            "trading_bloc": self.trading_bloc,
             "commodity": self.commodity.to_dict()
         }

--- a/barriers/models/history/barriers.py
+++ b/barriers/models/history/barriers.py
@@ -67,7 +67,7 @@ class CommoditiesHistoryItem(BaseHistoryItem):
 
     @property
     def diff(self):
-        grouped = self.get_values_grouped_by_country()
+        grouped = self.get_values_grouped_by_location()
         diff = {}
         for country_name, item in grouped.items():
             old_codes = set([value["code"] for value in item["old_value"]])
@@ -87,16 +87,24 @@ class CommoditiesHistoryItem(BaseHistoryItem):
 
         return diff
 
-    def get_values_grouped_by_country(self):
+    def get_location_name(self, value):
+        if value.get("country"):
+            return value["country"]["name"]
+        elif value.get("trading_bloc"):
+            return value["trading_bloc"]["name"]
+
+    def get_values_grouped_by_location(self):
         grouped = {}
 
         for value in self.old_value:
-            grouped.setdefault(value["country"]["name"], {"old_value": [], "new_value": []})
-            grouped[value["country"]["name"]]["old_value"].append(value)
+            key = self.get_location_name(value)
+            grouped.setdefault(key, {"old_value": [], "new_value": []})
+            grouped[key]["old_value"].append(value)
 
         for value in self.new_value:
-            grouped.setdefault(value["country"]["name"], {"old_value": [], "new_value": []})
-            grouped[value["country"]["name"]]["new_value"].append(value)
+            key = self.get_location_name(value)
+            grouped.setdefault(key, {"old_value": [], "new_value": []})
+            grouped[key]["new_value"].append(value)
 
         return grouped
 

--- a/barriers/views/commodities.py
+++ b/barriers/views/commodities.py
@@ -76,7 +76,7 @@ class BarrierEditCommodities(BarrierMixin, FormView):
 
     def get_locations(self):
         if self.barrier.country:
-            default_location = self.barrier.country,
+            default_location = self.barrier.country
         elif self.barrier.trading_bloc:
             default_location = {
                 "id": self.barrier.trading_bloc["code"],

--- a/core/frontend/src/js/react/commodities/CommodityForm.js
+++ b/core/frontend/src/js/react/commodities/CommodityForm.js
@@ -3,13 +3,13 @@ import React, { useEffect, useRef, useState } from "react"
 import CodeInput from "./CodeInput"
 import CodeTextArea from "./CodeTextArea"
 import CommodityList from "./CommodityList"
-import CountryInput from "./CountryInput"
+import LocationInput from "./LocationInput"
 import ErrorBanner from "../forms/ErrorBanner"
 
 
 function CommodityForm(props) {
   const [codeArray, setCodeArray] = useState(["", "", "", "", ""])
-  const [countryId, setCountryId] = useState(props.countries[0]["id"])
+  const [locationId, setLocationId] = useState(props.locations[0]["id"])
   const [confirmedCommodities, setConfirmedCommodities] = useState(props.confirmedCommodities)
   const [unconfirmedCommodities, setUnconfirmedCommodities] = useState([])
   const [pastedCodes, setPastedCodes] = useState("")
@@ -18,8 +18,8 @@ function CommodityForm(props) {
   const boxCount = 5
   const inputRefContainer = useRef(new Array(boxCount))
 
-  const handleCountryChange = (event) => {
-    setCountryId(event.target.value)
+  const handleLocationChange = (event) => {
+    setLocationId(event.target.value)
   }
 
   const handleCodeChange = (event, index) => {
@@ -52,7 +52,7 @@ function CommodityForm(props) {
       let code = getCode()
       lookupCode(code)
     }
-  }, [countryId]);
+  }, [locationId]);
 
   const clearCodeInput = () => {
     for (var input of inputRefContainer.current) {
@@ -99,7 +99,7 @@ function CommodityForm(props) {
       return
     }
     setIsLoading(true)
-    const url = "?code=" + code + "&country=" + countryId
+    const url = "?code=" + code + "&location=" + locationId
     const response = await fetch(url, {
       headers: {
         "X-Requested-With": "XMLHttpRequest"
@@ -137,7 +137,7 @@ function CommodityForm(props) {
       setUnconfirmedCommodities([])
       return
     }
-    const url = "?codes=" + codes + "&country=" + countryId
+    const url = "?codes=" + codes + "&location=" + locationId
     const response = await fetch(url, {
       headers: {
         "X-Requested-With": "XMLHttpRequest"
@@ -178,7 +178,7 @@ function CommodityForm(props) {
             <legend className="govuk-fieldset__legend govuk-fieldset__legend--s">{props.label}</legend>
             <span className="govuk-hint">{props.helpText}</span>
 
-            <CountryInput countries={props.countries} countryId={countryId} onChange={handleCountryChange} />
+            <LocationInput locations={props.locations} locationId={locationId} onChange={handleLocationChange} />
 
             {codeLookupError ? (
               <span class="govuk-error-message">
@@ -232,9 +232,20 @@ function CommodityForm(props) {
         {confirmedCommodities.map((commodity, index) =>
           <input type="hidden" name="codes" value={commodity.code} />
         )}
-        {confirmedCommodities.map((commodity, index) =>
-          <input type="hidden" name="countries" value={commodity.country.id} />
-        )}
+        {confirmedCommodities.map((commodity, index) => {
+          if (commodity.country) {
+            return <input type="hidden" name="countries" value={commodity.country.id} />
+          } else {
+            return <input type="hidden" name="countries" value="" />
+          }
+        })}
+        {confirmedCommodities.map((commodity, index) => {
+          if (commodity.trading_bloc) {
+            return <input type="hidden" name="trading_blocs" value={commodity.trading_bloc.code} />
+          } else {
+            return <input type="hidden" name="trading_blocs" value="" />
+          }
+        })}
         <button name="action" value="save" class="govuk-button" data-module="govuk-button">Done</button>
         <button class="form-cancel govuk-button button-as-link" name="action" value="cancel">Cancel</button>
       </form>

--- a/core/frontend/src/js/react/commodities/LocationInput.js
+++ b/core/frontend/src/js/react/commodities/LocationInput.js
@@ -1,7 +1,7 @@
 import React from "react";
 
 
-function CountryInput(props) {
+function LocationInput(props) {
   return (
     <div className="govuk-form-group govuk-!-margin-top-5">
       <fieldset className="govuk-fieldset">
@@ -9,19 +9,19 @@ function CountryInput(props) {
           Which location are the commodity codes from?
         </legend>
 
-        <div className="govuk-radios country govuk-radios--inline" data-module="radios">
-          {props.countries.map((country, index) =>
+        <div className="govuk-radios location govuk-radios--inline" data-module="radios">
+          {props.locations.map((location, index) =>
             <div className="govuk-radios__item">
               <input
                 className="govuk-radios__input"
-                id={"country-" + country.id}
-                name="country"
+                id={"location-" + location.id}
+                name="location"
                 type="radio"
-                value={country.id}
-                defaultChecked={country.id == props.countryId}
+                value={location.id}
+                defaultChecked={location.id == props.locationId}
                 onChange={props.onChange}
               />
-              <label className="govuk-label govuk-radios__label" for={"country-" + country.id}>{country.name}</label>
+              <label className="govuk-label govuk-radios__label" for={"location-" + location.id}>{location.name}</label>
             </div>
           )}
         </div>
@@ -31,4 +31,4 @@ function CountryInput(props) {
 }
 
 
-export default CountryInput
+export default LocationInput

--- a/core/frontend/src/js/react/index.js
+++ b/core/frontend/src/js/react/index.js
@@ -6,13 +6,13 @@ import LocationFilter from "./search/LocationFilter"
 import {getCSRFToken, getCheckboxValues} from "./utils"
 
 
-function renderCommodityForm(confirmedCommodities, countries, label, helpText) {
+function renderCommodityForm(confirmedCommodities, locations, label, helpText) {
   const csrfToken = getCSRFToken()
   ReactDOM.render(
     <CommodityForm
       csrfToken={csrfToken}
       confirmedCommodities={confirmedCommodities}
-      countries={countries}
+      locations={locations}
       label={label}
       helpText={helpText}
     />,

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -144,7 +144,11 @@
             <dd class="summary-group__list__value">
                 {% if barrier.commodities %}
                     {% for country_id, commodity_list in barrier.commodities_grouped_by_country.items %}
-                        <span class="commodity-summary__country">These codes are for {{ commodity_list.0.country.name }}</span>
+                        {% if commodity_list.0.country %}
+                            <span class="commodity-summary__country">These codes are for {{ commodity_list.0.country.name }}</span>
+                        {% elif commodity_list.0.trading_bloc %}
+                            <span class="commodity-summary__country">These codes are for {{ commodity_list.0.trading_bloc.name }}</span>
+                        {% endif %}
                         <ul class="commodity-summary">
                             {% for commodity in commodity_list %}
                                 <li class="commodity-summary__item">

--- a/templates/barriers/edit/commodities.html
+++ b/templates/barriers/edit/commodities.html
@@ -8,13 +8,13 @@
   <script>
     document.addEventListener("DOMContentLoaded", function(event) {
       let confirmedCommodities = JSON.parse(document.getElementById('confirmed-commodities-data').textContent);
-      let countries = [
-        {"id": "{{ lookup_form.country.field.choices.0.0 }}", "name": "{{ lookup_form.country.field.choices.0.1 }}"},
-        {"id": "{{ lookup_form.country.field.choices.1.0 }}", "name": "{{ lookup_form.country.field.choices.1.1 }}"},
+      let locations = [
+        {"id": "{{ lookup_form.location.field.choices.0.0 }}", "name": "{{ lookup_form.location.field.choices.0.1 }}"},
+        {"id": "{{ lookup_form.location.field.choices.1.0 }}", "name": "{{ lookup_form.location.field.choices.1.1 }}"},
       ]
       ReactApp.renderCommodityForm(
         confirmedCommodities=confirmedCommodities,
-        countries=countries,
+        locations=locations,
         label="{{ lookup_form.code.label }}",
         helpText="{{ lookup_form.code.help_text }}",
       )
@@ -42,7 +42,7 @@
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">{{ lookup_form.code.label }}</legend>
                     <span class="govuk-hint">{{ lookup_form.code.help_text }}</span>
 
-                    {% include "partials/forms/radio_input.html" with field=lookup_form.country radio_classes="govuk-radios--inline" classes="govuk-!-margin-top-5" strong=False %}
+                    {% include "partials/forms/radio_input.html" with field=lookup_form.location radio_classes="govuk-radios--inline" classes="govuk-!-margin-top-5" strong=False %}
 
                     {% form_field_error lookup_form.code %}
 
@@ -58,7 +58,7 @@
             <form action="" method="POST">
                 {% csrf_token %}
                 <input type="hidden" name="code" value="{{ lookup_form.commodity.code }}" />
-                <input type="hidden" name="country" value="{{ lookup_form.country.value }}" />
+                <input type="hidden" name="location" value="{{ lookup_form.location.value }}" />
 
                 <ul class="commodities-list restrict-width">
                     <li class="commodities-list__item">
@@ -93,6 +93,7 @@
             {% for confirmed_commodity in confirmed_commodities %}
                 <input type="hidden" name="codes" value="{{ confirmed_commodity.code }}" />
                 <input type="hidden" name="countries" value="{{ confirmed_commodity.country.id }}" />
+                <input type="hidden" name="trading_blocs" value="{{ confirmed_commodity.trading_bloc.code }}" />
             {% endfor %}
             <button name="action" value="save" class="govuk-button" data-module="govuk-button">Done</button>
             <button class="form-cancel govuk-button button-as-link" name="action" value="cancel">Cancel</button>

--- a/utils/metadata.py
+++ b/utils/metadata.py
@@ -367,6 +367,9 @@ class Metadata:
                     "short_name": trading_bloc["short_name"],
                 }
 
+    def is_trading_bloc_code(self, code):
+        return self.get_trading_bloc(code) is not None
+
     def get_wto_committee_groups(self):
         return self.data.get("wto_committee_groups", [])
 


### PR DESCRIPTION
* Commodities can now be associated to a trading bloc (or a country)
* Rename commodity form fields and React components to `location` instead of `country`
* Ensure commodity trading blocs are handled correctly
* Update commodity history item
* Update tests
