### PR TITLE
MAR-535: Public resolution status

### DIFF
--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -181,6 +181,21 @@ class PublicBarrier(APIModel):
             return dateutil.parser.parse(self.data["internal_status_date"])
 
     @property
+    def is_resolved_text(self):
+        return self.get_resolved_text(self.is_resolved, self.status_date)
+
+    @property
+    def internal_is_resolved_text(self):
+        return self.get_resolved_text(self.internal_is_resolved, self.internal_status_date)
+
+    def get_resolved_text(self, is_resolved, status_date):
+        if is_resolved:
+            if status_date:
+                return f"Yes - {status_date.strftime('%B %Y')}"
+            return "Yes"
+        return "No"
+
+    @property
     def status_date(self):
         if self.data.get("status_date"):
             return dateutil.parser.parse(self.data["status_date"])

--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -176,6 +176,11 @@ class PublicBarrier(APIModel):
         return [category["title"] for category in self.internal_categories]
 
     @property
+    def internal_status_date(self):
+        if self.data.get("internal_status_date"):
+            return dateutil.parser.parse(self.data["internal_status_date"])
+
+    @property
     def first_published_on(self):
         if self.data.get("first_published_on") is not None:
             return dateutil.parser.parse(self.data["first_published_on"])

--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -181,6 +181,11 @@ class PublicBarrier(APIModel):
             return dateutil.parser.parse(self.data["internal_status_date"])
 
     @property
+    def status_date(self):
+        if self.data.get("status_date"):
+            return dateutil.parser.parse(self.data["status_date"])
+
+    @property
     def first_published_on(self):
         if self.data.get("first_published_on") is not None:
             return dateutil.parser.parse(self.data["first_published_on"])

--- a/barriers/models/history/public_barriers.py
+++ b/barriers/models/history/public_barriers.py
@@ -2,6 +2,8 @@ from barriers.constants import PUBLIC_BARRIER_STATUSES
 from .base import BaseHistoryItem, GenericHistoryItem
 from .utils import PolymorphicBase
 
+import dateutil.parser
+
 
 class CategoriesHistoryItem(BaseHistoryItem):
     field = "categories"
@@ -55,6 +57,8 @@ class StatusHistoryItem(BaseHistoryItem):
         value["status_text"] = self.metadata.get_status_text(
             status_id=value["status"],
         )
+        if value["status_date"]:
+            value["status_date"] = dateutil.parser.parse(value["status_date"])
         return value
 
 

--- a/barriers/models/history/public_barriers.py
+++ b/barriers/models/history/public_barriers.py
@@ -48,7 +48,7 @@ class SectorsHistoryItem(BaseHistoryItem):
 
 class StatusHistoryItem(BaseHistoryItem):
     field = "status"
-    field_name = "Public status"
+    field_name = "Public resolved status"
     modifier = "status"
 
     def get_value(self, value):

--- a/barriers/views/statuses.py
+++ b/barriers/views/statuses.py
@@ -20,7 +20,7 @@ class BarrierEditStatus(APIBarrierFormViewMixin, FormView):
         initial = {"status_summary": self.object.status_summary}
 
         if self.is_barrier_resolved():
-            initial["status_date"] = self.object.status["date"]
+            initial["status_date"] = self.object.status_date
         return initial
 
     def get_form_kwargs(self):

--- a/core/tests.py
+++ b/core/tests.py
@@ -122,6 +122,10 @@ class MarketAccessTestCase(TestCase):
             "summary": "Public summary",
             "public_view_status": 20,
             "status": 0,
+            "is_resolved": False,
+            "internal_is_resolved": False,
+            "status_date": None,
+            "internal_status_date": None,
         }
 
     @property

--- a/templates/barriers/activity/partials/public_barrier/status.html
+++ b/templates/barriers/activity/partials/public_barrier/status.html
@@ -1,1 +1,1 @@
-{% include "barriers/activity/partials/public_barrier/base.html" with update_text="Barrier status was updated" %}
+{% include "barriers/activity/partials/public_barrier/base.html" with update_text="Barrier resolved status was updated" %}

--- a/templates/barriers/history/partials/public_barrier/status.html
+++ b/templates/barriers/history/partials/public_barrier/status.html
@@ -1,14 +1,11 @@
-{% if item.old_value.status != None %}
-    <div class="history-item__old-value">
-        <span class="diff__del">
-            {{ item.old_value.status_text }}
-        </span>
-    </div>
-{% endif %}
-{% if item.new_value.status != None %}
-    <div class="history-item__new-value">
-        <span class="diff__ins">
-            {{ item.new_value.status_text }}
-        </span>
-    </div>
-{% endif %}
+<div class="history-item__old-value">
+    <span class="diff__del">
+        {{ item.old_value.is_resolved|yesno:"Yes,No" }}
+    </span>
+</div>
+
+<div class="history-item__new-value">
+    <span class="diff__ins">
+        {{ item.new_value.is_resolved|yesno:"Yes,No" }}
+    </span>
+</div>

--- a/templates/barriers/history/partials/public_barrier/status.html
+++ b/templates/barriers/history/partials/public_barrier/status.html
@@ -1,11 +1,11 @@
 <div class="history-item__old-value">
     <span class="diff__del">
-        {{ item.old_value.is_resolved|yesno:"Yes,No" }}
+        {{ item.old_value.is_resolved|yesno:"Yes,No" }}{% if item.old_value.is_resolved %} - {{ item.old_value.status_date|date:"F Y" }}{% endif %}
     </span>
 </div>
 
 <div class="history-item__new-value">
     <span class="diff__ins">
-        {{ item.new_value.is_resolved|yesno:"Yes,No" }}
+        {{ item.new_value.is_resolved|yesno:"Yes,No" }}{% if item.new_value.is_resolved %} - {{ item.new_value.status_date|date:"F Y" }}{% endif %}
     </span>
 </div>

--- a/templates/barriers/public_barriers/detail.html
+++ b/templates/barriers/public_barriers/detail.html
@@ -126,13 +126,17 @@
                 {% endif %}
             </dd>
 
-            <dt class="summary-group__list__key">Status</dt>
+            <dt class="summary-group__list__key">Resolved</dt>
             <dd class="summary-group__list__value">
-                {% if public_barrier.internal_status_changed and public_barrier.first_published_on %}
-                    <span class="diff__del diff__del--block">{{ public_barrier.latest_published_version.status.name }}</span>
-                    <span class="diff__ins diff__ins--block">{{ public_barrier.internal_status.name }}</span>
+                {% if public_barrier.internal_is_resolved_changed or public_barrier.internal_status_date_changed and public_barrier.first_published_on %}
+                    <span class="diff__del diff__del--block">
+                        {{ public_barrier.latest_published_version.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.latest_published_version.internal_is_resolved and public_barrier.latest_published_version.internal_status_date %} - {{ public_barrier.latest_published_version.internal_status_date|date:"F Y" }}{% endif %}
+                    </span>
+                    <span class="diff__ins diff__ins--block">
+                        {{ public_barrier.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.internal_is_resolved and public_barrier.internal_status_date %} - {{ public_barrier.internal_status_date|date:"F Y" }}{% endif %}
+                    </span>
                 {% else %}
-                    {{ public_barrier.internal_status.name }}
+                    {{ public_barrier.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.internal_is_resolved and public_barrier.internal_status_date %} - {{ public_barrier.internal_status_date|date:"F Y" }}{% endif %}
                 {% endif %}
             </dd>
 

--- a/templates/barriers/public_barriers/detail.html
+++ b/templates/barriers/public_barriers/detail.html
@@ -130,13 +130,13 @@
             <dd class="summary-group__list__value">
                 {% if public_barrier.internal_is_resolved_changed or public_barrier.internal_status_date_changed and public_barrier.first_published_on %}
                     <span class="diff__del diff__del--block">
-                        {{ public_barrier.latest_published_version.is_resolved|yesno:"Yes,No" }}{% if public_barrier.latest_published_version.is_resolved and public_barrier.latest_published_version.status_date %} - {{ public_barrier.latest_published_version.status_date|date:"F Y" }}{% endif %}
+                        {{ public_barrier.latest_published_version.is_resolved_text }}
                     </span>
                     <span class="diff__ins diff__ins--block">
-                        {{ public_barrier.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.internal_is_resolved and public_barrier.internal_status_date %} - {{ public_barrier.internal_status_date|date:"F Y" }}{% endif %}
+                        {{ public_barrier.internal_is_resolved_text }}
                     </span>
                 {% else %}
-                    {{ public_barrier.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.internal_is_resolved and public_barrier.internal_status_date %} - {{ public_barrier.internal_status_date|date:"F Y" }}{% endif %}
+                    {{ public_barrier.internal_is_resolved_text }}
                 {% endif %}
             </dd>
 

--- a/templates/barriers/public_barriers/detail.html
+++ b/templates/barriers/public_barriers/detail.html
@@ -130,7 +130,7 @@
             <dd class="summary-group__list__value">
                 {% if public_barrier.internal_is_resolved_changed or public_barrier.internal_status_date_changed and public_barrier.first_published_on %}
                     <span class="diff__del diff__del--block">
-                        {{ public_barrier.latest_published_version.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.latest_published_version.internal_is_resolved and public_barrier.latest_published_version.internal_status_date %} - {{ public_barrier.latest_published_version.internal_status_date|date:"F Y" }}{% endif %}
+                        {{ public_barrier.latest_published_version.is_resolved|yesno:"Yes,No" }}{% if public_barrier.latest_published_version.is_resolved and public_barrier.latest_published_version.status_date %} - {{ public_barrier.latest_published_version.status_date|date:"F Y" }}{% endif %}
                     </span>
                     <span class="diff__ins diff__ins--block">
                         {{ public_barrier.internal_is_resolved|yesno:"Yes,No" }}{% if public_barrier.internal_is_resolved and public_barrier.internal_status_date %} - {{ public_barrier.internal_status_date|date:"F Y" }}{% endif %}


### PR DESCRIPTION
* Display `Resolved: Yes/No` (with status date if applicable) instead of `Status: xxx` for public barriers