### PR TITLE
MAR-339: Avoid module level get_metadata calls

### DIFF
--- a/barriers/models/history/base.py
+++ b/barriers/models/history/base.py
@@ -1,11 +1,11 @@
 from utils.diff import diff_match_patch
-from utils.metadata import get_metadata
+from utils.metadata import MetadataMixin
 from utils.models import APIModel
 
 import dateutil.parser
 
 
-class BaseHistoryItem(APIModel):
+class BaseHistoryItem(MetadataMixin, APIModel):
     _metadata = None
     _new_value = None
     _old_value = None
@@ -14,12 +14,6 @@ class BaseHistoryItem(APIModel):
     @property
     def date(self):
         return dateutil.parser.parse(self.data["date"])
-
-    @property
-    def metadata(self):
-        if self._metadata is None:
-            self._metadata = get_metadata()
-        return self._metadata
 
     @property
     def new_value(self):

--- a/barriers/views/categories.py
+++ b/barriers/views/categories.py
@@ -7,10 +7,10 @@ from ..forms.categories import (
     AddCategoryForm,
     EditCategoriesForm,
 )
-from utils.metadata import get_metadata
+from utils.metadata import MetadataMixin
 
 
-class AddCategory(BarrierMixin, FormView):
+class AddCategory(MetadataMixin, BarrierMixin, FormView):
     template_name = "barriers/edit/categories/add.html"
     form_class = AddCategoryForm
 
@@ -28,14 +28,13 @@ class AddCategory(BarrierMixin, FormView):
         """
         Get a list of all categories excluding any already selected
         """
-        metadata = get_metadata()
         selected_category_ids = [
             str(category["id"])
             for category in self.request.session.get("categories", [])
         ]
         return [
             category
-            for category in metadata.get_category_list()
+            for category in self.metadata.get_category_list()
             if str(category["id"]) not in selected_category_ids
         ]
 
@@ -43,8 +42,7 @@ class AddCategory(BarrierMixin, FormView):
         """
         Add the new category to the session and redirect
         """
-        metadata = get_metadata()
-        category = metadata.get_category(form.cleaned_data["category"])
+        category = self.metadata.get_category(form.cleaned_data["category"])
         categories = self.request.session.get("categories", [])
         categories.append(
             {"id": category["id"], "title": category["title"],}
@@ -59,7 +57,7 @@ class AddCategory(BarrierMixin, FormView):
         )
 
 
-class BarrierEditCategories(BarrierMixin, FormView):
+class BarrierEditCategories(MetadataMixin, BarrierMixin, FormView):
     template_name = "barriers/edit/categories/edit.html"
     form_class = EditCategoriesForm
     use_session_categories = False
@@ -86,8 +84,7 @@ class BarrierEditCategories(BarrierMixin, FormView):
         kwargs = super().get_form_kwargs()
         kwargs["barrier_id"] = str(self.kwargs.get("barrier_id"))
         kwargs["token"] = self.request.session.get("sso_token")
-        metadata = get_metadata()
-        kwargs["categories"] = metadata.get_category_list()
+        kwargs["categories"] = self.metadata.get_category_list()
         return kwargs
 
     def form_valid(self, form):

--- a/barriers/views/edit.py
+++ b/barriers/views/edit.py
@@ -13,7 +13,7 @@ from barriers.forms.edit import (
     UpdateCausedByTradingBlocForm,
     UpdateTradeDirectionForm,
 )
-from utils.metadata import get_metadata
+from utils.metadata import MetadataMixin
 
 
 class BarrierEditTitle(APIBarrierFormViewMixin, FormView):
@@ -80,10 +80,9 @@ class BarrierEditEndDate(APIBarrierFormViewMixin, FormView):
         return {"end_date": self.barrier.end_date}
 
 
-class BarrierEditTags(APIBarrierFormViewMixin, FormView):
+class BarrierEditTags(MetadataMixin, APIBarrierFormViewMixin, FormView):
     template_name = "barriers/edit/tags.html"
     form_class = UpdateBarrierTagsForm
-    metadata = get_metadata()
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -94,10 +93,9 @@ class BarrierEditTags(APIBarrierFormViewMixin, FormView):
         return {"tags": [tag["id"] for tag in self.barrier.tags]}
 
 
-class BarrierEditTradeDirection(APIBarrierFormViewMixin, FormView):
+class BarrierEditTradeDirection(MetadataMixin, APIBarrierFormViewMixin, FormView):
     template_name = "barriers/edit/trade_direction.html"
     form_class = UpdateTradeDirectionForm
-    metadata = get_metadata()
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()

--- a/barriers/views/sectors.py
+++ b/barriers/views/sectors.py
@@ -7,10 +7,10 @@ from barriers.forms.sectors import (
     AddSectorsForm,
     EditSectorsForm,
 )
-from utils.metadata import get_metadata
+from utils.metadata import MetadataMixin
 
 
-class BarrierEditSectors(BarrierMixin, FormView):
+class BarrierEditSectors(MetadataMixin, BarrierMixin, FormView):
     template_name = "barriers/edit/sectors.html"
     form_class = EditSectorsForm
     use_session_sectors = False
@@ -24,12 +24,11 @@ class BarrierEditSectors(BarrierMixin, FormView):
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        metadata = get_metadata()
         sector_ids = self.request.session.get("sectors", [])
 
         context_data.update(
             {
-                "sectors": metadata.get_sectors_by_ids(sector_ids),
+                "sectors": self.metadata.get_sectors_by_ids(sector_ids),
                 "all_sectors": self.request.session.get("all_sectors"),
             }
         )
@@ -53,10 +52,9 @@ class BarrierEditSectors(BarrierMixin, FormView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        metadata = get_metadata()
         kwargs["sectors"] = [
             (sector["id"], sector["name"])
-            for sector in metadata.get_sector_list(level=0)
+            for sector in self.metadata.get_sector_list(level=0)
         ]
         kwargs["barrier_id"] = str(self.kwargs.get("barrier_id"))
         kwargs["token"] = self.request.session.get("sso_token")
@@ -67,24 +65,21 @@ class BarrierEditSectorsSession(BarrierEditSectors):
     use_session_sectors = True
 
 
-class BarrierAddSectors(BarrierMixin, FormView):
+class BarrierAddSectors(MetadataMixin, BarrierMixin, FormView):
     template_name = "barriers/edit/add_sectors.html"
     form_class = AddSectorsForm
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
-        metadata = get_metadata()
         sector_ids = self.request.session.get("sectors", [])
-        context_data["sectors"] = metadata.get_sectors_by_ids(sector_ids)
+        context_data["sectors"] = self.metadata.get_sectors_by_ids(sector_ids)
         return context_data
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
-        metadata = get_metadata()
-
         kwargs["sectors"] = [
             (sector["id"], sector["name"])
-            for sector in metadata.get_sector_list(level=0)
+            for sector in self.metadata.get_sector_list(level=0)
             if sector["id"] not in self.request.session.get("sectors", [])
         ]
         return kwargs

--- a/reports/views.py
+++ b/reports/views.py
@@ -34,7 +34,7 @@ from reports.helpers import ReportFormGroup
 
 from utils.api.client import MarketAccessAPIClient
 from utils.exceptions import APIHttpException
-from utils.metadata import get_metadata, MetadataMixin
+from utils.metadata import MetadataMixin
 
 
 class CalloutMixin(ContextMixin):
@@ -76,11 +76,11 @@ class ReportBarrierContextMixin(CalloutMixin):
         return context_data
 
 
-class ReportsTemplateView(ReportBarrierContextMixin, TemplateView):
+class ReportsTemplateView(MetadataMixin, ReportBarrierContextMixin, TemplateView):
     """A base view for displaying a report template with optional callout."""
 
 
-class ReportsFormView(ReportBarrierContextMixin, FormView):
+class ReportsFormView(MetadataMixin, ReportBarrierContextMixin, FormView):
     """
     A base view for displaying a report template with forms and optional callout.
     If both provided in the view back_path overrides back_url.
@@ -185,10 +185,10 @@ class NewReport(ReportsTemplateView):
         )
     )
 
-    metadata = get_metadata()
-    extra_context = {
-        "stages": metadata.get_report_stages()
-    }
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["stages"] = self.metadata.get_report_stages()
+        return context_data
 
 
 class NewReportBarrierTermView(ReportsFormView):
@@ -227,7 +227,7 @@ class NewReportBarrierStatusView(ReportsFormView):
         return context_data
 
 
-class NewReportBarrierLocationView(MetadataMixin, ReportsFormView):
+class NewReportBarrierLocationView(ReportsFormView):
     heading_text = "Location of the barrier"
     template_name = "reports/new_report_barrier_location.html"
     form_class = NewReportBarrierLocationForm
@@ -294,7 +294,6 @@ class NewReportBarrierLocationAddAdminAreasView(ReportsFormView):
     success_path = "reports:barrier_admin_areas"
     extra_paths = {'back': 'reports:barrier_has_admin_areas'}
     form_session_key = FormSessionKeys.ADMIN_AREAS
-    metadata = get_metadata()
 
     @property
     def selected_admin_areas(self):
@@ -354,7 +353,6 @@ class NewReportBarrierAdminAreasView(ReportsFormView):
         'remove_admin_area': 'reports:barrier_remove_admin_areas'
     }
     form_class = NewReportBarrierLocationAdminAreasForm
-    metadata = get_metadata()
 
     @property
     def selected_admin_areas(self):
@@ -381,7 +379,7 @@ class NewReportBarrierLocationRemoveAdminAreasView(ReportsFormView):
         return HttpResponseRedirect(self.get_success_url())
 
 
-class NewReportBarrierCausedByTradingBlocView(MetadataMixin, ReportsFormView):
+class NewReportBarrierCausedByTradingBlocView(ReportsFormView):
     heading_text = "Location of the barrier"
     template_name = "reports/new_report_caused_by_trading_bloc.html"
     form_class = NewReportCausedByTradingBlocForm
@@ -403,7 +401,6 @@ class NewReportBarrierTradeDirectionView(ReportsFormView):
     form_class = NewReportBarrierTradeDirectionForm
     extra_paths = {'back': 'reports:barrier_location'}
     form_session_key = FormSessionKeys.TRADE_DIRECTION
-    metadata = get_metadata()
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -456,7 +453,6 @@ class NewReportBarrierSectorsView(ReportsFormView):
         'add_all': 'reports:barrier_add_all_sectors',
         'remove_sector': 'reports:barrier_remove_sector'
     }
-    metadata = get_metadata()
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
@@ -484,7 +480,6 @@ class NewReportBarrierSectorsAddView(ReportsFormView):
     extra_paths = {
         'back': 'reports:barrier_sectors',
     }
-    metadata = get_metadata()
 
     def get_context_data(self, **kwargs):
         context_data = super().get_context_data(**kwargs)
@@ -518,7 +513,6 @@ class NewReportBarrierSectorsAddView(ReportsFormView):
 class NewReportBarrierSectorsAddAllView(ReportsFormView):
     http_method_names = 'post'
     success_path = 'reports:barrier_sectors'
-    metadata = get_metadata()
 
     def post(self, request, *args, **kwargs):
         self.init_view(request, **kwargs)
@@ -546,7 +540,6 @@ class NewReportBarrierAboutView(ReportsFormView):
     form_class = NewReportBarrierAboutForm
     extra_paths = {'back': 'reports:barrier_sectors'}
     form_session_key = FormSessionKeys.ABOUT
-    metadata = get_metadata()
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
* Move `get_metadata` calls out of class level definitions so it gets called at runtime instead of deploy time.