### PR TITLE
TSS-248: Remove filter that causes wrong checkboxes to be checked

### DIFF
--- a/templates/partials/forms/checkbox_filter.html
+++ b/templates/partials/forms/checkbox_filter.html
@@ -15,7 +15,7 @@
                            id="{{ field.name }}-{{ forloop.counter }}"
                            name="{{ field.name }}"
                            type="checkbox"
-                           value="{{ value }}" {% if value|lower in field.value|lower %}checked="checked"{% endif %}>
+                           value="{{ value }}" {% if value|lower in field.value %}checked="checked"{% endif %}>
 
                     <label class="govuk-label checkbox-filter__label" for="{{ field.name }}-{{ forloop.counter }}">
                       {{ text|safe }}


### PR DESCRIPTION
The problem is that at line 18 of checkbox_filter.html, the `lower` filter converts its value to a string, but the field for GovOrg is a multiple choice field, so its value is a list. In the case of the Treasury, id 12, that means it's converted to "[12]". Then, when rendering all the possible values for the field, the checkboxes with values '1' and '2' pass that test, so they get checked!