### PR TITLE
Sort out horizontal and vertical separation of tags.

### DIFF
--- a/core/frontend/src/css/app-objects/_tags.scss
+++ b/core/frontend/src/css/app-objects/_tags.scss
@@ -17,5 +17,6 @@
 }
 
 .barrier-tag-list > .govuk-tag {
-    margin-right: 1em;
+    margin-right: govuk-spacing(3);
+    margin-bottom: govuk-spacing(2);
 }


### PR DESCRIPTION
Changed it to use the govuk-spacing() function, because it's there :-)