### PR TITLE
Fix - TSS-815- Report barrier edit pages bugs

### DIFF
--- a/barriers/forms/edit.py
+++ b/barriers/forms/edit.py
@@ -1046,7 +1046,9 @@ class UpdateBarrierStartDateForm(ClearableMixin, APIFormMixin, forms.Form):
         return cleaned_data
 
     def clean_start_date(self):
-        return self.cleaned_data["start_date"].isoformat()
+        if start_data := self.cleaned_data["start_date"]:
+            return start_data.isoformat()
+        return None
 
     def save(self):
         client = MarketAccessAPIClient(self.token)

--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -377,6 +377,14 @@ class Barrier(APIModel):
     def export_description(self):
         return self.data.get("export_description", "")
 
+    @property
+    def main_sector(self):
+        return self.data.get("main_sector", "")
+
+    @property
+    def all_sectors(self):
+        return self.data.get("all_sectors", False)
+
 
 class PublicBarrier(APIModel):
     _country = None

--- a/templates/barriers/barrier_detail.html
+++ b/templates/barriers/barrier_detail.html
@@ -371,9 +371,9 @@
                     {% else %}
                         <span class="summary-group__list__value__list__item">{{ barrier.main_sector.name|default:"Unknown"}}</span>
                     {% endif %}
-                    {% if not barrier.archived %}
+                {% endif %}
+                {% if not barrier.archived %}
                     <a class="summary-group__list__value__edit" href="{% url 'barriers:add_main_sector' barrier.id %}">Edit</a>
-                    {% endif %}
                 {% endif %}
             </dd>
             <dt class="summary-group__list__key">Other sector{{ barrier.sectors|pluralize }} affected:</dt>

--- a/templates/barriers/edit/export_type.html
+++ b/templates/barriers/edit/export_type.html
@@ -13,7 +13,7 @@
     {% form_error_banner form %}
 
     <div class="restrict-width">
-        <form method="post">
+        <form method="post" novalidate>
             {% csrf_token %}
             <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">


### PR DESCRIPTION
Added main_sector and all_sectors to Barrier model 

Fixed ValidationError with the 'barrier start date' form. Trying to convert Nonetype to a date caused error, return None instead and let the 'required' error message trigger.

Added no validate to export type edit page.

'Add main sector' button now appears on the barrier detail page if one is not provided.