### PR TITLE
Fix - TSS-532 - Reunion islands formatting error

### DIFF
--- a/core/fixtures/metadata.json
+++ b/core/fixtures/metadata.json
@@ -1918,7 +1918,7 @@
     },
     {
       "id": "5761b8be-5d95-e211-a939-e4115bead28a",
-      "name": "R\\u00e9union",
+      "name": "Réunion",
       "disabled_on": "2018-11-05T17:00:00Z",
       "overseas_region": {
         "name": "Europe",


### PR DESCRIPTION
json.loads uses UTF-8 by default to parse the fake metadata, so we can put the accented e directly in the .json. At least I think that's how encoding works...