### PR TITLE
Fix - TSS-895 - Submitting empty CSAT form error

### DIFF
--- a/barriers/forms/feedback.py
+++ b/barriers/forms/feedback.py
@@ -50,9 +50,9 @@ class FeedbackForm(forms.Form):
         cleaned_data = super().clean()
         satisfaction = cleaned_data.get("satisfaction", None)
         csat_submission = cleaned_data.get("csat_submission", False)
-        if csat_submission == "False" and (satisfaction is None or satisfaction == ""):
+        if not satisfaction:
             self.add_error("satisfaction", "You must select a level of satisfaction")
-        if csat_submission == "True":
+        elif csat_submission == "True":
             client = MarketAccessAPIClient(self.token)
             feedback = client.feedback.send_feedback(
                 token=self.token, **self.cleaned_data

--- a/tests/feedback/test_feedback.py
+++ b/tests/feedback/test_feedback.py
@@ -33,7 +33,7 @@ class FeedbackTestCase(MarketAccessTestCase):
         assert "satisfaction" in form.errors
 
     @patch("utils.api.resources.FeedbackResource.send_feedback")
-    def test_csat_redirect_does_not_require_satisfaction_level(
+    def test_csat_redirect_requires_satisfaction_level(
         self, mock_send_feedback_method: Mock
     ):
         mock_send_feedback_method.return_value = {"id": str(uuid.uuid4())}
@@ -47,7 +47,7 @@ class FeedbackTestCase(MarketAccessTestCase):
         )
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
-        assert "satisfaction" not in form.errors
+        assert "satisfaction" in form.errors
 
     @patch("utils.api.resources.FeedbackResource.send_feedback")
     def test_feedback_requires_attempted_action(self, mock_send_feedback_method: Mock):

--- a/tests/feedback/test_feedback.py
+++ b/tests/feedback/test_feedback.py
@@ -32,7 +32,10 @@ class FeedbackTestCase(MarketAccessTestCase):
         form = response.context["form"]
         assert "satisfaction" in form.errors
 
-    def test_csat_redirect_requires_satisfaction_level(self):
+    @patch("utils.api.resources.FeedbackResource.send_feedback")
+    def test_csat_redirect_requires_satisfaction_level(
+        self, mock_send_feedback_method: Mock
+    ):
         url = reverse(
             "core:feedback",
         )
@@ -44,6 +47,7 @@ class FeedbackTestCase(MarketAccessTestCase):
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
         assert "satisfaction" in form.errors
+        mock_send_feedback_method.assert_not_called()
 
     @patch("utils.api.resources.FeedbackResource.send_feedback")
     def test_csat_redirect_with_satisfaction_level(

--- a/tests/feedback/test_feedback.py
+++ b/tests/feedback/test_feedback.py
@@ -32,11 +32,7 @@ class FeedbackTestCase(MarketAccessTestCase):
         form = response.context["form"]
         assert "satisfaction" in form.errors
 
-    @patch("utils.api.resources.FeedbackResource.send_feedback")
-    def test_csat_redirect_requires_satisfaction_level(
-        self, mock_send_feedback_method: Mock
-    ):
-        mock_send_feedback_method.return_value = {"id": str(uuid.uuid4())}
+    def test_csat_redirect_requires_satisfaction_level(self):
         url = reverse(
             "core:feedback",
         )
@@ -48,6 +44,24 @@ class FeedbackTestCase(MarketAccessTestCase):
         assert response.status_code == HTTPStatus.OK
         form = response.context["form"]
         assert "satisfaction" in form.errors
+
+    @patch("utils.api.resources.FeedbackResource.send_feedback")
+    def test_csat_redirect_with_satisfaction_level(
+        self, mock_send_feedback_method: Mock
+    ):
+        mock_send_feedback_method.return_value = {"id": str(uuid.uuid4())}
+        url = reverse(
+            "core:feedback",
+        )
+        response = self.client.post(
+            url,
+            follow=False,
+            data={"csat_submission": "True", "satisfaction": "SATISFIED"},
+        )
+        assert response.status_code == HTTPStatus.OK
+        form = response.context["form"]
+        assert "satisfaction" not in form.errors
+        mock_send_feedback_method.assert_called()
 
     @patch("utils.api.resources.FeedbackResource.send_feedback")
     def test_feedback_requires_attempted_action(self, mock_send_feedback_method: Mock):


### PR DESCRIPTION
User must now select a satisfaction rating on the star csat_rating partial at the end of barrier creation journey. A validationError is raised otherwise.