### PR TITLE
Fix - TSS-1358 - CSP report issue

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -408,12 +408,14 @@ EXTERNAL_URLS_FIND_EXPORTERS = env.str("EXTERNAL_URLS_FIND_EXPORTERS", "")
 COMPANIES_HOUSE_API_KEY = env("COMPANIES_HOUSE_API_KEY")
 COMPANIES_HOUSE_API_ENDPOINT = env("COMPANIES_HOUSE_API_ENDPOINT")
 
-CSP_DEFAULT_SRC = (
+CSP_DEFAULT_SRC = ("'self'",)
+CSP_SCRIPT_SRC = (
     "'self'",
     "https://www.googletagmanager.com/",
     "https://*.google-analytics.com",
     "https://www.google-analytics.com",
 )
+CSP_CONNECT_SRC = CSP_SCRIPT_SRC
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
 CSP_REPORT_URI = "/csp_report"
 CSP_INCLUDE_NONCE_IN = ["script-src"]

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -413,6 +413,7 @@ CSP_SCRIPT_SRC = (
     "'self'",
     "https://www.googletagmanager.com/",
     "https://*.google-analytics.com",
+    "https://www.google-analytics.com",
 )
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
 CSP_REPORT_URI = "/csp_report"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -408,8 +408,7 @@ EXTERNAL_URLS_FIND_EXPORTERS = env.str("EXTERNAL_URLS_FIND_EXPORTERS", "")
 COMPANIES_HOUSE_API_KEY = env("COMPANIES_HOUSE_API_KEY")
 COMPANIES_HOUSE_API_ENDPOINT = env("COMPANIES_HOUSE_API_ENDPOINT")
 
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = (
+CSP_DEFAULT_SRC = (
     "'self'",
     "https://www.googletagmanager.com/",
     "https://*.google-analytics.com",

--- a/core/views.py
+++ b/core/views.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 import sentry_sdk
@@ -16,7 +17,7 @@ logger = logging.getLogger(__name__)
 class CSPReportView(View):
     def post(self, request, *args, **kwargs):
         with sentry_sdk.configure_scope() as scope:
-            report = request.body.decode("utf-8")
+            csp_report = json.loads(request.body.decode("utf-8"))["csp-report"]
             scope.set_tag("type", "csp_report")
-            logger.error("CSP Blocked", extra={"report": report})
+            logger.error("CSP Blocked", extra=csp_report)
         return HttpResponse(status=200)

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,6 @@
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default:'en' }}" class="govuk-template {{ htmlClasses }}">
   <head>
-    <script>console.log("test")</script>
     <!-- Google Tag Manager -->
     <script nonce="{{request.csp_nonce}}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,6 +5,7 @@
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default:'en' }}" class="govuk-template {{ htmlClasses }}">
   <head>
+    <script>console.log("test")</script>
     <!-- Google Tag Manager -->
     <script nonce="{{request.csp_nonce}}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
The sentry warnings were coming from the conncet-src CSP directive, which google analytics tags load as part of their initial script.