### PR TITLE
Fix - TSS-1069 - Admin areas search form bug

### DIFF
--- a/barriers/forms/search.py
+++ b/barriers/forms/search.py
@@ -426,6 +426,10 @@ class BarrierSearchForm(forms.Form):
                 if f"status_date_{status_value}" in params:
                     del params[f"status_date_{status_value}"]
 
+        # tss-1069 - we need to encode the admin_areas as string JSON in the URL
+        if "admin_areas" in params:
+            params = format_dict_for_url_querystring(params, ["admin_areas"])
+
         return urlencode(params, doseq=True)
 
     def get_api_search_parameters(self):


### PR DESCRIPTION
We need to encode the admin_areas as string JSON in the URL, otherwise the react component breaks when we pass in comma-separated values as defined in the JSONField to_python method