### PR TITLE
MAU Rebase test - IGNORE THIS

### DIFF
--- a/barriers/constants.py
+++ b/barriers/constants.py
@@ -78,12 +78,12 @@ UK_COUNTRY_ID = "80756b9a-5d95-e211-a939-e4115bead28a"
 
 PUBLIC_BARRIER_STATUSES = Choices(
     ("0", "UNKNOWN", "To be decided"),
-    ("10", "INELIGIBLE", "Not allowed"),
-    ("20", "ELIGIBLE", "Allowed"),
-    ("30", "READY", "Ready"),
+    ("10", "NOT_ALLOWED", "Not allowed"),
+    ("20", "ALLOWED", "Allowed"),
+    ("70", "APPROVAL_PENDING", "Awaiting approval"),
+    ("30", "PUBLISHING_PENDING", "Awaiting publishing"),
     ("40", "PUBLISHED", "Published"),
     ("50", "UNPUBLISHED", "Unpublished"),
-    ("60", "REVIEW_LATER", "Barriers marked as 'review later'"),
 )
 
 

--- a/barriers/forms/mixins.py
+++ b/barriers/forms/mixins.py
@@ -28,6 +28,7 @@ class APIFormMixin:
         self.action_plan = kwargs.pop("action_plan", None)
         self.milestone_id = kwargs.pop("milestone_id", None)
         self.task_id = kwargs.pop("task_id", None)
+        self.countdown = kwargs.pop("countdown", None)
         super().__init__(*args, **kwargs)
 
 

--- a/barriers/forms/public_barriers.py
+++ b/barriers/forms/public_barriers.py
@@ -1,140 +1,230 @@
+import logging
+
 from django import forms
 from django.http import QueryDict
 
 from barriers.constants import AWAITING_REVIEW_FROM, PUBLIC_BARRIER_STATUSES
 from utils.api.client import MarketAccessAPIClient
+from utils.forms.fields import TrueFalseBooleanField
 from utils.metadata import Metadata
 
 from .mixins import APIFormMixin
 
+logger = logging.getLogger(__name__)
+
 
 class PublicEligibilityForm(APIFormMixin, forms.Form):
-    public_eligibility = forms.ChoiceField(
-        label="Does this barrier meet the criteria to be made public?",
-        choices=(
-            ("yes", "Allowed, it can be viewed by the public"),
-            ("no", "Not allowed"),
-            ("review_later", "Review later"),
-        ),
-        error_messages={"required": "Enter yes, no or review later"},
-    )
-    allowed_summary = forms.CharField(
-        label="Why is it allowed to be public? (optional)",
-        widget=forms.Textarea,
-        max_length=250,
-        required=False,
-        error_messages={
-            "max_length": "Public eligibility summary should be %(limit_value)d characters or fewer",
-        },
-    )
-    not_allowed_summary = forms.CharField(
-        label="Why is it not allowed to be public?",
-        widget=forms.Textarea,
-        max_length=250,
-        required=False,
-        error_messages={
-            "max_length": "Public eligibility summary should be %(limit_value)d characters or fewer",
-        },
-    )
-    review_later_summary = forms.CharField(
-        label="Why should this barrier be reviewed at a later date?",
-        widget=forms.Textarea,
-        max_length=250,
-        required=False,
-        error_messages={
-            "max_length": "Public eligibility summary should be %(limit_value)d characters or fewer",
-        },
-    )
 
-    def get_summary(self):
-        if self.cleaned_data.get("public_eligibility") == "yes":
-            return self.cleaned_data.get("allowed_summary")
-        elif self.cleaned_data.get("public_eligibility") == "no":
-            return self.cleaned_data.get("not_allowed_summary")
-        elif self.cleaned_data.get("public_eligibility") == "review_later":
-            return self.cleaned_data.get("review_later_summary")
-        return ""
+    public_eligibility = forms.ChoiceField(
+        label="Should this barrier be made public on GOV.UK, once it has been approved?",
+        help_text="All market access barriers should be published unless there is a valid reason not to.",
+        choices=(
+            ("yes", "Yes, it can be published once approved"),
+            ("no", "No, it cannot be published"),
+        ),
+        required=False,
+    )
+    public_eligibility_summary = forms.CharField(
+        label="Explain why the barrier should not be published",
+        widget=forms.Textarea(
+            attrs={
+                "class": "govuk-textarea",
+                "rows": 5,
+            },
+        ),
+        required=False,
+        initial="",
+    )
 
     def clean(self):
-        data = self.cleaned_data
-        public_eligibility = data.get("public_eligibility", None)
-        if public_eligibility == "no" and not data.get("not_allowed_summary"):
-            raise forms.ValidationError(
-                "Summary required if public view status is not allowed"
-            )
-        if public_eligibility == "review_later" and not data.get(
-            "review_later_summary"
+        cleaned_data = super().clean()
+
+        # Need to check for required field. Needs to be done here or the key
+        # will be missing for the summary check later in the method.
+        if (
+            "public_eligibility" not in cleaned_data.keys()
+            or cleaned_data["public_eligibility"] == ""
         ):
-            raise forms.ValidationError(
-                "Summary required if public view status is be reviewed later"
-            )
-        return data
+            msg = "Select whether this barrier should be published on GOV.UK, once approved"
+            self.add_error("public_eligibility", msg)
+            return
+
+        # Summary required if barrier cannot be published
+        if (
+            cleaned_data["public_eligibility"] == "no"
+            and cleaned_data["public_eligibility_summary"] == ""
+        ):
+            msg = "Enter a reason for not publishing this barrier"
+            self.add_error("public_eligibility_summary", msg)
 
     def save(self):
         client = MarketAccessAPIClient(self.token)
-        if self.cleaned_data.get("public_eligibility") == "review_later":
-            client.barriers.patch(
+
+        client.barriers.patch(
+            id=self.id,
+            public_eligibility=self.cleaned_data.get("public_eligibility"),
+            public_eligibility_summary=self.cleaned_data.get(
+                "public_eligibility_summary"
+            ),
+        )
+
+        if self.cleaned_data.get("public_eligibility") == "no":
+            # Clear public title and summary of the barrier in case we are changing this
+            # barrier to Not Allowed from previously Allowed
+            client.public_barriers.report_public_barrier_field(
                 id=self.id,
-                public_eligibility_postponed=True,
-                public_eligibility=False,
-                public_eligibility_summary=self.get_summary(),
+                form_name="barrier-public-title",
+                values={"title": ""},
             )
-        else:
-            client.barriers.patch(
+            client.public_barriers.report_public_barrier_field(
                 id=self.id,
-                public_eligibility=self.cleaned_data.get("public_eligibility") == "yes",
-                public_eligibility_postponed=False,
-                public_eligibility_summary=self.get_summary(),
+                form_name="barrier-public-summary",
+                values={"summary": ""},
             )
 
 
 class PublishTitleForm(APIFormMixin, forms.Form):
     title = forms.CharField(
-        label="Title",
-        max_length=255,
+        label="Public title",
+        help_text=("Provide a title that is suitable for the public to read."),
+        max_length=150,
         error_messages={
-            "max_length": "Title should be %(limit_value)d characters or fewer",
-            "required": "Enter a title",
+            "max_length": "Title should be %(limit_value)d characters or less",
+            "required": "Enter a public title for this barrier",
         },
-        help_text=(
-            "<a href='https://data-services-help.trade.gov.uk/market-access/how-guides/"
-            "how-prepare-market-access-barrier-report-public-view/' target='_blank'>"
-            "How to write a title for public view"
-            "</a>"
+        widget=forms.Textarea(
+            attrs={
+                "class": "govuk-input govuk-js-character-count js-character-count",
+                "rows": 10,
+            },
         ),
     )
 
     def save(self):
         client = MarketAccessAPIClient(self.token)
-        client.public_barriers.patch(
+
+        client.public_barriers.report_public_barrier_field(
             id=self.id,
-            title=self.cleaned_data.get("title"),
+            form_name="barrier-public-title",
+            values={"title": self.cleaned_data.get("title")},
         )
 
 
 class PublishSummaryForm(APIFormMixin, forms.Form):
     summary = forms.CharField(
-        label="Summary",
-        widget=forms.Textarea,
+        label="Public summary",
+        help_text=("Provide a summary that is suitable for the public to read."),
         max_length=1500,
         error_messages={
-            "max_length": "Summary should be %(limit_value)d characters or fewer",
-            "required": "Enter a summary",
+            "max_length": "Summary should be %(limit_value)d characters or less",
+            "required": "Enter a public summary for this barrier",
         },
-        help_text=(
-            "<a href='https://data-services-help.trade.gov.uk/market-access/how-guides/"
-            "how-prepare-market-access-barrier-report-public-view/' target='_blank'>"
-            "How to write a summary for public view"
-            "</a>"
+        widget=forms.Textarea(
+            attrs={
+                "class": "govuk-textarea govuk-js-character-count js-character-count",
+                "rows": 5,
+            },
         ),
     )
 
     def save(self):
         client = MarketAccessAPIClient(self.token)
+
+        client.public_barriers.report_public_barrier_field(
+            id=self.id,
+            form_name="barrier-public-summary",
+            values={"summary": self.cleaned_data.get("summary")},
+        )
+
+
+class ApprovePublicBarrierForm(APIFormMixin, forms.Form):
+    confirmation = TrueFalseBooleanField(
+        required=True,
+        label=(
+            """
+            I confirm that this barrier can be approved for
+            publication and it has been reviewed with all parties listed on this page.
+            """
+        ),
+        widget=forms.CheckboxInput(
+            attrs={
+                "class": "govuk-checkboxes__input",
+            },
+        ),
+    )
+    public_approval_summary = forms.CharField(
+        label="Is there anything else you want to add about how you've reached your decision for approval? (optional)",
+        max_length=500,
+        required=False,
+        error_messages={
+            "max_length": "Summary should be %(limit_value)d characters or less",
+        },
+        widget=forms.Textarea(
+            attrs={
+                "class": "govuk-textarea govuk-js-character-count js-character-count",
+                "rows": 5,
+            },
+        ),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if cleaned_data["confirmation"] is False:
+            msg = "Confirm if the barrier is approved"
+            self.add_error("confirmation", msg)
+
+    def save(self):
+        client = MarketAccessAPIClient(self.token)
+
+        public_approval_summary = self.cleaned_data.get("public_approval_summary")
+        if public_approval_summary != "":
+            client.public_barriers.patch(
+                id=self.id,
+                approvers_summary=public_approval_summary,
+            )
+
+        client.public_barriers.ready_for_publishing(id=self.id)
+
+
+class PublishPublicBarrierForm(APIFormMixin, forms.Form):
+    def save(self):
+        client = MarketAccessAPIClient(self.token)
+        client.public_barriers.publish(id=self.id)
+
+
+class UnpublishPublicBarrierForm(APIFormMixin, forms.Form):
+    public_publisher_summary = forms.CharField(
+        label="Reason for removing the barrier",
+        max_length=500,
+        required=False,
+        error_messages={
+            "max_length": "Summary should be %(limit_value)d characters or less",
+        },
+        widget=forms.Textarea(
+            attrs={
+                "class": "govuk-textarea govuk-js-character-count js-character-count",
+                "rows": 5,
+            },
+        ),
+    )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if cleaned_data["public_publisher_summary"] == "":
+            msg = "Provide a reason for unpublishing the barrier."
+            self.add_error("public_publisher_summary", msg)
+
+    def save(self):
+        client = MarketAccessAPIClient(self.token)
+
         client.public_barriers.patch(
             id=self.id,
-            summary=self.cleaned_data.get("summary"),
+            publishers_summary=self.cleaned_data.get("public_publisher_summary"),
         )
+
+        client.public_barriers.unpublish(id=self.id)
 
 
 class PublicBarrierSearchForm(forms.Form):

--- a/barriers/forms/search.py
+++ b/barriers/forms/search.py
@@ -144,14 +144,13 @@ class BarrierSearchForm(forms.Form):
     public_view = forms.MultipleChoiceField(
         label="Public view",
         choices=(
-            ("not_yet_sifted", "Not yet sifted"),
-            ("eligible", "Allowed to be published"),
-            ("ineligible", "Not allowed to be published"),
-            ("ready", "Ready to publish"),
+            ("unknown", "To be decided"),
+            ("allowed", "Allowed to be published"),
+            ("not_allowed", "Not allowed to be published"),
+            ("awaiting_approval", "Awaiting Approval"),
+            ("ready_for_publishing", "Awaiting Publishing"),
             ("published", "Published"),
-            ("changed", "Barriers changed internally since being made public"),
             ("unpublished", "Unpublished"),
-            ("review_later", "Barriers marked as 'review later'"),
         ),
         required=False,
     )

--- a/barriers/models/barriers.py
+++ b/barriers/models/barriers.py
@@ -567,12 +567,16 @@ class PublicBarrier(APIModel):
 
     @property
     def tab_badge(self):
-        if str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.ELIGIBLE:
+        if str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.ALLOWED:
             return "Allowed"
-        elif str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.READY:
-            return "Ready"
+        elif str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.APPROVAL_PENDING:
+            return "Awaiting approval"
+        elif str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.PUBLISHING_PENDING:
+            return "Awaiting publishing"
         elif str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.PUBLISHED:
             return "Published"
+        elif str(self.public_view_status) == PUBLIC_BARRIER_STATUSES.UNPUBLISHED:
+            return "Awaiting re-publishing"
 
     @property
     def reported_on(self):

--- a/barriers/urls.py
+++ b/barriers/urls.py
@@ -133,8 +133,11 @@ from .views.public_barriers import (
     EditPublicEligibility,
     EditPublicSummary,
     EditPublicTitle,
+    PublicBarrierApprovalConfirmation,
     PublicBarrierDetail,
     PublicBarrierListView,
+    PublicBarrierPublishConfirmation,
+    PublicBarrierUnpublishConfirmation,
 )
 from .views.saved_searches import (
     DeleteSavedSearch,
@@ -782,19 +785,34 @@ urlpatterns = [
         name="public_barrier_detail",
     ),
     path(
-        "barriers/<uuid:barrier_id>/public/eligibility/",
+        "barriers/<uuid:barrier_id>/public/eligibility/<int:countdown>",
         EditPublicEligibility.as_view(),
         name="edit_public_eligibility",
     ),
     path(
-        "barriers/<uuid:barrier_id>/public/title/",
+        "barriers/<uuid:barrier_id>/public/title/<int:countdown>",
         EditPublicTitle.as_view(),
         name="edit_public_barrier_title",
     ),
     path(
-        "barriers/<uuid:barrier_id>/public/summary/",
+        "barriers/<uuid:barrier_id>/public/summary/<int:countdown>",
         EditPublicSummary.as_view(),
         name="edit_public_barrier_summary",
+    ),
+    path(
+        "barriers/<uuid:barrier_id>/public/public_approve/<int:countdown>",
+        PublicBarrierApprovalConfirmation.as_view(),
+        name="approve_public_barrier_confirmation",
+    ),
+    path(
+        "barriers/<uuid:barrier_id>/public/public_publish/",
+        PublicBarrierPublishConfirmation.as_view(),
+        name="publish_public_barrier_confirmation",
+    ),
+    path(
+        "barriers/<uuid:barrier_id>/public/public_unpublish/",
+        PublicBarrierUnpublishConfirmation.as_view(),
+        name="unpublish_public_barrier_confirmation",
     ),
     path(
         "barriers/<uuid:barrier_id>/mark_approved",

--- a/barriers/views/public_barriers.py
+++ b/barriers/views/public_barriers.py
@@ -1,22 +1,31 @@
+import logging
+from datetime import datetime, timedelta, timezone
 from urllib.parse import parse_qs
 
+from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import FormView
 
 from barriers.forms.notes import AddPublicBarrierNoteForm, EditPublicBarrierNoteForm
 from barriers.forms.public_barriers import (
+    ApprovePublicBarrierForm,
     PublicBarrierSearchForm,
     PublicEligibilityForm,
+    PublishPublicBarrierForm,
     PublishSummaryForm,
     PublishTitleForm,
+    UnpublishPublicBarrierForm,
 )
+from users.mixins import UserMixin
 from utils.api.client import MarketAccessAPIClient
 from utils.helpers import remove_empty_values_from_dict
 from utils.metadata import MetadataMixin
 
 from .mixins import APIBarrierFormViewMixin, BarrierMixin, PublicBarrierMixin
 from .search import SearchFormView
+
+logger = logging.getLogger(__name__)
 
 
 class PublicBarrierListView(MetadataMixin, SearchFormView):
@@ -74,7 +83,9 @@ class PublicBarrierListView(MetadataMixin, SearchFormView):
         return data
 
 
-class PublicBarrierDetail(MetadataMixin, PublicBarrierMixin, BarrierMixin, FormView):
+class PublicBarrierDetail(
+    MetadataMixin, PublicBarrierMixin, BarrierMixin, UserMixin, FormView
+):
     template_name = "barriers/public_barriers/detail.html"
 
     def get_activity(self):
@@ -90,12 +101,55 @@ class PublicBarrierDetail(MetadataMixin, PublicBarrierMixin, BarrierMixin, FormV
         return activity_items
 
     def get_context_data(self, **kwargs):
+        client = MarketAccessAPIClient(self.request.session.get("sso_token"))
         context_data = super().get_context_data(**kwargs)
+
+        # Establish type of user accessing the page and pass to template
+        # Users can only be in one of these categories.
+        user_groups = client.users.get_current().groups_display
+        if "Public barrier approver" in user_groups:
+            context_data["user_role"] = "Approver"
+        elif "Publisher" in user_groups:
+            context_data["user_role"] = "Publisher"
+        else:
+            context_data["user_role"] = "General user"
+
         context_data["activity_items"] = self.get_activity()
+
+        # Check the activiy items and find the latest public_view_status activity
+        # which updated the value to Awaiting publishing, send the users name to the template
+        for item in context_data["activity_items"]:
+            if isinstance(item.new_value, dict) and item.new_value.get(
+                "public_view_status"
+            ):
+                if item.new_value["public_view_status"][
+                    "name"
+                ] == "Awaiting publishing" and not context_data.get("approver_name"):
+                    context_data["approver_name"] = item.user["name"]
+                if item.new_value["public_view_status"][
+                    "name"
+                ] == "Published" and not context_data.get("publisher_name"):
+                    context_data["publisher_name"] = item.user["name"]
+                    context_data["published_date"] = item.date
+                # There is a 30 day limit after a barrier is set to 'Allowed' for
+                # it to be moved into 'Published'. A countdown is displayed in the frontend
+                # status box so we need to obtain that count here.
+                if item.new_value["public_view_status"][
+                    "name"
+                ] == "Allowed" and not context_data.get("countdown"):
+                    published_deadline = item.date + timedelta(days=30)
+                    deadline_difference = published_deadline - datetime.now(
+                        timezone.utc
+                    )
+                    # Add day to round up spare hours/mins
+                    if deadline_difference.days < 0:
+                        context_data["countdown"] = 0
+                    else:
+                        context_data["countdown"] = deadline_difference.days + 1
+
         context_data["add_note"] = self.request.GET.get("add-note")
         context_data["edit_note"] = self.request.GET.get("edit-note")
         context_data["delete_note"] = self.request.GET.get("delete-note")
-        context_data["gov_organisations"] = self.metadata.get_gov_organisation_dict()
         return context_data
 
     def get_form_class(self):
@@ -134,21 +188,54 @@ class PublicBarrierDetail(MetadataMixin, PublicBarrierMixin, BarrierMixin, FormV
 
     def post(self, request, *args, **kwargs):
         action = self.request.POST.get("action")
-
+        context_data = self.get_context_data()
         if action:
             client = MarketAccessAPIClient(self.request.session.get("sso_token"))
             barrier_id = self.kwargs.get("barrier_id")
 
-            if action == "mark-as-ready":
-                client.public_barriers.mark_as_ready(id=barrier_id)
-            elif action == "publish":
-                client.public_barriers.publish(id=barrier_id)
-            elif action == "mark-as-in-progress":
-                client.public_barriers.mark_as_in_progress(id=barrier_id)
-            elif action == "unpublish":
-                client.public_barriers.unpublish(id=barrier_id)
-            elif action == "ignore-changes":
-                client.public_barriers.ignore_all_changes(id=barrier_id)
+            if action == "submit-for-approval":
+                client.public_barriers.ready_for_approval(id=barrier_id)
+                submitted_for_approval_success_message = f"""
+                    The approver is the person who checks the public title and summary, and gets
+                    clearances. For example, a Grade 6 or 7 in a regional team or a Market Access Coordinator at Post.
+                    Once it has been approved the barrier will be sent to the GOV.UK team for final content
+                    checks. It can then be published.
+                    This needs to be done within the next {context_data["countdown"]} days.
+                    For more details see the barrier information and notes on the public view tab
+                    """
+                messages.add_message(
+                    self.request,
+                    messages.INFO,
+                    submitted_for_approval_success_message,
+                    extra_tags="This barrier is now awaiting approval",
+                )
+            elif action == "remove-for-approval":
+                client.public_barriers.allow_for_publishing_process(id=barrier_id)
+                approval_revoked_success_message = """
+                    The person who approves this barrier has reverted the barrier publication status to:
+                    awaiting approval.
+                    For more details see the barrier information and notes on the public view tab
+                    """
+                messages.add_message(
+                    self.request,
+                    messages.INFO,
+                    approval_revoked_success_message,
+                    extra_tags="This barrier is not ready for approval",
+                )
+            elif action == "remove-for-publishing":
+                client.public_barriers.ready_for_approval(id=barrier_id)
+                publish_rejection_success_message = """
+                    The GOV.UK content team can not publish the barrier until it is approved again. To do this
+                    the approver will need to complete their checks and submit the barrier for approval.
+                    For more details see the barrier information and notes the publisher has added on the
+                    public view tab.
+                    """
+                messages.add_message(
+                    self.request,
+                    messages.INFO,
+                    publish_rejection_success_message,
+                    extra_tags="This barrier needs to be approved again",
+                )
             elif action == "delete-note":
                 note_id = self.request.POST.get("note_id")
                 client.public_barrier_notes.delete(id=note_id)
@@ -157,7 +244,7 @@ class PublicBarrierDetail(MetadataMixin, PublicBarrierMixin, BarrierMixin, FormV
             form = self.get_form()
             if form.is_valid():
                 return self.form_valid(form)
-        return self.render_to_response(self.get_context_data())
+        return self.render_to_response(context_data)
 
     def get_success_url(self):
         return reverse(
@@ -169,14 +256,25 @@ class PublicBarrierDetail(MetadataMixin, PublicBarrierMixin, BarrierMixin, FormV
 class EditPublicEligibility(APIBarrierFormViewMixin, FormView):
     template_name = "barriers/public_barriers/eligibility.html"
     form_class = PublicEligibilityForm
+    success_message_eligible = """
+        But it cannot be approved until a public title and summary are added.
+        It will then be reviewed by the approver who checks the public title and summary, and gets
+        clearances. The GOV.UK can then review the content and publish it.
+        This needs to be done within the next %d days.
+        Add the public title and summary on the public view tab.
+        """
+    success_message_not_eligible = """
+        To start the approval process to decide if this barrier can be made public on GOV.UK, first
+        update the barrier publication status to 'allowed' and add the public title and summary.
+        It will then be reviewed by the approver who checks the public title and summary, and gets
+        clearances. The GOV.UK can then review the content and publish it.
+        For more details see the barrier information the public view tab.
+        """
 
     def get_initial(self):
         barrier_public_eligibility = self.barrier.public_eligibility
-        barrier_public_eligibility_postponed = self.barrier.public_eligibility_postponed
 
-        if barrier_public_eligibility_postponed:
-            public_eligibility = "review_later"
-        elif barrier_public_eligibility:
+        if barrier_public_eligibility:
             public_eligibility = "yes"
         else:
             public_eligibility = "no"
@@ -184,15 +282,30 @@ class EditPublicEligibility(APIBarrierFormViewMixin, FormView):
         initial = {
             "public_eligibility": public_eligibility,
         }
-        if public_eligibility == "review_later":
-            initial["review_later_summary"] = self.barrier.public_eligibility_summary
-        elif public_eligibility == "no":
+        if public_eligibility == "no":
             initial["not_allowed_summary"] = self.barrier.public_eligibility_summary
-        elif public_eligibility == "yes":
+        else:
             initial["allowed_summary"] = self.barrier.public_eligibility_summary
+
         return initial
 
     def get_success_url(self):
+        form = self.get_form()
+        if form.data["public_eligibility"] == "yes":
+            messages.add_message(
+                self.request,
+                messages.INFO,
+                (self.success_message_eligible % self.kwargs["countdown"]),
+                extra_tags="The barrier publication status has been set to: allowed",
+            )
+        else:
+            messages.add_message(
+                self.request,
+                messages.INFO,
+                self.success_message_not_eligible,
+                extra_tags="The publication status is set to: not allowed",
+            )
+
         return reverse(
             "barriers:public_barrier_detail",
             kwargs={"barrier_id": self.kwargs.get("barrier_id")},
@@ -202,11 +315,29 @@ class EditPublicEligibility(APIBarrierFormViewMixin, FormView):
 class EditPublicTitle(APIBarrierFormViewMixin, PublicBarrierMixin, FormView):
     template_name = "barriers/public_barriers/title.html"
     form_class = PublishTitleForm
+    success_message = """
+        But the barrier cannot be approved until there is both a public title and summary.
+        This needs to be done within the next %d days, along with a review from the approver,
+        and the GOV.UK publishing team.
+        Add the public title and summary on the public view tab.
+        """
 
     def get_initial(self):
         return {"title": self.public_barrier.title}
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["internal_title"] = self.barrier.title
+        context_data["internal_summary"] = self.barrier.summary
+        return context_data
+
     def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            (self.success_message % self.kwargs["countdown"]),
+            extra_tags="The public title has been added",
+        )
         return reverse(
             "barriers:public_barrier_detail",
             kwargs={"barrier_id": self.kwargs.get("barrier_id")},
@@ -216,11 +347,102 @@ class EditPublicTitle(APIBarrierFormViewMixin, PublicBarrierMixin, FormView):
 class EditPublicSummary(APIBarrierFormViewMixin, PublicBarrierMixin, FormView):
     template_name = "barriers/public_barriers/summary.html"
     form_class = PublishSummaryForm
+    success_message = """
+        But the barrier cannot be approved until there is both a public title and summary.
+        This needs to be done within the next %d days, along with a review from the approver,
+        and the GOV.UK publishing team.
+        Add the public title and summary on the public view tab.
+        """
 
     def get_initial(self):
         return {"summary": self.public_barrier.summary}
 
+    def get_context_data(self, **kwargs):
+        context_data = super().get_context_data(**kwargs)
+        context_data["internal_title"] = self.barrier.title
+        context_data["internal_summary"] = self.barrier.summary
+        return context_data
+
     def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            (self.success_message % self.kwargs["countdown"]),
+            extra_tags="The public summary has been added",
+        )
+        return reverse(
+            "barriers:public_barrier_detail",
+            kwargs={"barrier_id": self.kwargs.get("barrier_id")},
+        )
+
+
+class PublicBarrierApprovalConfirmation(
+    APIBarrierFormViewMixin, PublicBarrierMixin, FormView
+):
+    template_name = "barriers/public_barriers/approval_confirmation.html"
+    form_class = ApprovePublicBarrierForm
+    success_message = """
+        Only a member of the GOV.UK publishing team can complete the content checks. They will
+        contact the approver if they need more information or context.
+        This needs to be done within the next %d days. The barrier can then be published.
+        This will be updated in the barrier publication status on the public view tab.
+        """
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            (self.success_message % self.kwargs["countdown"]),
+            extra_tags="This barrier has been approved and is now with the GOV.UK content team",
+        )
+        return reverse(
+            "barriers:public_barrier_detail",
+            kwargs={"barrier_id": self.kwargs.get("barrier_id")},
+        )
+
+
+class PublicBarrierPublishConfirmation(
+    APIBarrierFormViewMixin,
+    PublicBarrierMixin,
+    FormView,
+):
+    template_name = "barriers/public_barriers/publish_confirmation.html"
+    form_class = PublishPublicBarrierForm
+    success_message = """
+        You can view the barrier on GOV.UK by visiting check international trade barriers.
+        For more details see the barrier information and notes on the public view tab.
+        """
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            self.success_message,
+            extra_tags="This barrier has been published on GOV.UK",
+        )
+        return reverse(
+            "barriers:public_barrier_detail",
+            kwargs={"barrier_id": self.kwargs.get("barrier_id")},
+        )
+
+
+class PublicBarrierUnpublishConfirmation(
+    APIBarrierFormViewMixin, PublicBarrierMixin, FormView
+):
+    template_name = "barriers/public_barriers/unpublish_confirmation.html"
+    form_class = UnpublishPublicBarrierForm
+    success_message = """
+        It can no longer be viewed on Check international trade barriers.
+        For more details see the barrier information and notes on the public view tab.
+        """
+
+    def get_success_url(self):
+        messages.add_message(
+            self.request,
+            messages.INFO,
+            self.success_message,
+            extra_tags="This barrier has been removed from GOV.UK",
+        )
         return reverse(
             "barriers:public_barrier_detail",
             kwargs={"barrier_id": self.kwargs.get("barrier_id")},

--- a/core/frontend/src/css/app-components/_notification-banner.scss
+++ b/core/frontend/src/css/app-components/_notification-banner.scss
@@ -34,3 +34,26 @@
         color: #1D70B8;
     }
 }
+
+.govuk-notification-banner--success {
+    border-color: #00703c;
+    background-color: #00703c;
+    width: 100%
+}
+
+.govuk-notification-banner--success__header {
+    padding: 2px 15px 5px;
+    border-bottom: 1px solid transparent;
+    background-color: #00703c;
+}
+
+.govuk-notification-banner--success__content {
+    box-sizing: border-box;
+}
+
+.govuk-notification-banner--success__content {
+    $padding-tablet: govuk-spacing(4);
+    @include govuk-text-colour;
+    padding: govuk-spacing(3);
+    background-color: $govuk-body-background-colour;
+  }

--- a/core/frontend/src/css/app-components/_summary-group.scss
+++ b/core/frontend/src/css/app-components/_summary-group.scss
@@ -23,6 +23,44 @@
     border-bottom: 4px solid $govuk-black;
 }
 
+.summary-group-public-view__heading {
+    @include govuk-font($size: 24, $weight: bold);
+    padding-bottom: govuk-em(10, 24);
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.public-view-information-box {
+    padding: 10px 10px 10px 10px;
+    flex: 1;
+    margin-bottom: 20px;
+    border: 2px solid #B1B4B6;
+}
+
+.public-view-information-box__notset {
+    border: 2px dotted #B1B4B6;
+    background-color: #f3f2f1;
+}
+
+.public-view-status-box {
+    padding: 16px;
+    margin-bottom: 20px;
+    flex: 1;
+    text-align: left;
+}
+
+.public-view-status-box__inprogress {
+    border: 3px solid #144E81;
+}
+
+.public-view-status-box__heading {
+    font-size: 22px;
+}
+
+.public-view-status-box__published {
+    border: 3px solid #00703C;
+}
+
 .summary-group__subheading {
     display: block;
     @include govuk-font($size: 16, $weight: bold);

--- a/core/frontend/src/css/pages/_all.scss
+++ b/core/frontend/src/css/pages/_all.scss
@@ -10,6 +10,7 @@
 
 @import 'report/sectors';
 @import 'report/check_answers';
+@import 'report/public_barrier_information';
 
 @import 'search';
 @import 'what-is-a-barrier';

--- a/core/frontend/src/css/pages/report/_public_barrier_information.scss
+++ b/core/frontend/src/css/pages/report/_public_barrier_information.scss
@@ -1,0 +1,6 @@
+.inset-banner {
+    color: rgb(11, 12, 12);
+    margin-bottom: 20px;
+    padding: 15px;
+    border-left: 10px solid rgb(244, 119, 56);
+}

--- a/core/tests.py
+++ b/core/tests.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.test import TestCase, override_settings
 from mock import patch
 
+from barriers.models.history import HistoryItem
 from core.filecache import memfiles
 from users.models import User
 from utils.api.resources import (
@@ -38,6 +39,7 @@ class MarketAccessTestCase(TestCase):
                 "set_topprioritybarrier",
                 "can_approve_estimated_completion_date",
             ],
+            "groups": [{"id": 4, "name": "Administrator"}],
         }
     )
     general_user = User(
@@ -45,6 +47,7 @@ class MarketAccessTestCase(TestCase):
             "is_superuser": False,
             "is_active": True,
             "permissions": [],
+            "groups": [],
         }
     )
     approver_user = User(
@@ -61,6 +64,7 @@ class MarketAccessTestCase(TestCase):
                 "archive_strategicassessment",
                 "approve_strategicassessment",
             ],
+            "groups": [{"id": 27, "name": "Public barrier approver"}],
         }
     )
     analyst_user = User(
@@ -76,8 +80,83 @@ class MarketAccessTestCase(TestCase):
                 "change_economicimpactassessment",
                 "archive_economicimpactassessment",
             ],
+            "groups": [{"id": 5, "name": "Analyst"}],
         }
     )
+    publisher_user = User(
+        {
+            "is_superuser": False,
+            "is_active": True,
+            "permissions": [
+                "add_resolvabilityassessment",
+                "change_resolvabilityassessment",
+                "archive_resolvabilityassessment",
+                "approve_resolvabilityassessment",
+                "add_strategicassessment",
+                "change_strategicassessment",
+                "archive_strategicassessment",
+                "approve_strategicassessment",
+            ],
+            "groups": [{"id": 6, "name": "Publisher"}],
+        }
+    )
+
+    public_barrier_activity = [
+        HistoryItem(
+            {
+                "date": "2020-03-19T09:18:16.687291Z",
+                "model": "public_barrier",
+                "field": "public_view_status",
+                "old_value": {
+                    "public_view_status": {"id": 0, "name": "Unknown"},
+                    "public_eligibility": False,
+                    "public_eligibility_summary": "",
+                },
+                "new_value": {
+                    "public_view_status": {"id": 10, "name": "Allowed"},
+                    "public_eligibility": True,
+                    "public_eligibility_summary": "",
+                },
+                "user": {"id": 48, "name": "Test-user"},
+            }
+        ),
+        HistoryItem(
+            {
+                "date": "2020-03-19T09:18:16.687291Z",
+                "model": "public_barrier",
+                "field": "public_view_status",
+                "old_value": {
+                    "public_view_status": {"id": 70, "name": "Awaiting approval"},
+                    "public_eligibility": True,
+                    "public_eligibility_summary": "",
+                },
+                "new_value": {
+                    "public_view_status": {"id": 30, "name": "Awaiting publishing"},
+                    "public_eligibility": True,
+                    "public_eligibility_summary": "",
+                },
+                "user": {"id": 48, "name": "Test-user"},
+            }
+        ),
+        HistoryItem(
+            {
+                "date": "2020-03-19T09:18:16.687291Z",
+                "model": "public_barrier",
+                "field": "public_view_status",
+                "old_value": {
+                    "public_view_status": {"id": 30, "name": "Awaiting publishing"},
+                    "public_eligibility": True,
+                    "public_eligibility_summary": "",
+                },
+                "new_value": {
+                    "public_view_status": {"id": 40, "name": "Published"},
+                    "public_eligibility": True,
+                    "public_eligibility_summary": "",
+                },
+                "user": {"id": 48, "name": "Test-user"},
+            }
+        ),
+    ]
 
     def setUp(self):
         self.init_session()

--- a/reports/views.py
+++ b/reports/views.py
@@ -22,6 +22,8 @@ class NewReport(TemplateView):
             "5": "which sectors the barrier affects",
             "6": "which companies the barrier affects",
             "7": "which goods and services or investments the barrier affects",
+            "8": "whether the barrier can be published on GOV.UK",
+            "9": "to provide a title and summary that are suitable for the public to read",
         }
         return context_data
 

--- a/templates/barriers/public_barriers/approval_confirmation.html
+++ b/templates/barriers/public_barriers/approval_confirmation.html
@@ -1,0 +1,69 @@
+{% extends "barriers/edit/base.html" %}
+
+{% block page_title %}{{ block.super }} Confirm Public Barrier Approval {% endblock %}
+
+{% block body_script %}
+    <script nonce="{{request.csp_nonce}}">
+        if( ma.components.CharacterCount ){
+            new ma.components.CharacterCount( '.govuk-character-count' );
+        }
+    </script>
+{% endblock %}
+
+{% block page_content %}
+
+    <form action="" novalidate method="POST" class="restrict-width">
+        {% csrf_token %}
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">Confirm this barrier has been approved</h1>
+        </legend>
+
+        <p class="govuk-body">By approving this barrier you confirm it should be published on GOV.UK, once they have completed their content checks.</p>
+        <p class="govuk-body">You also confirm that you have reviewed it with the following people or organisations:</p>
+        <ul class="govuk-lis govuk-list--bullet govuk-list--spaced">
+            <li class="govuk-body">Market Access Regional Coordinators</li>
+            <li class="govuk-body">BTR Regional Teams</li>
+            {% for item in barrier.government_organisations %}
+                <li class="govuk-body">{{ item.name }}</li>
+            {% endfor %}
+        </ul>
+
+        {% form_error_banner form %}
+
+        <div id="{{ form.confirmation.name }}" class="govuk-form-group govuk-!-margin-top-6 {% if form.confirmation.errors %} govuk-form-group--error{% endif %}">
+            {% form_field_error form "confirmation" %}
+            <div class="govuk-form-group">
+                <fieldset class="govuk-fieldset">
+                    <div class="govuk-checkboxes" data-module="govuk-checkboxes">
+                        <div class="govuk-checkboxes__item">
+                            <input class="govuk-checkboxes__input" id="{{ form.confirmation.name }}" name="{{ form.confirmation.name }}" type="checkbox" {% if form.confirmation.value == "True" %}checked="checked"{% endif %}>
+                            <label class="govuk-label govuk-checkboxes__label" for={{ form.confirmation.name }}>
+                                {{ form.confirmation.label }}
+                            </label>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+        </div>
+
+        <div id="{{ form.public_approval_summary.name }}"
+             class="govuk-character-count"
+             data-module="character-count"
+             data-maxlength="500">
+            <div class="{% form_group_classes form.public_approval_summary.errors %}">
+                {% form_field_error form "public_approval_summary" %}
+                <span id="{{ form.public_approval_summary.name }}_label" class="govuk-label govuk-label--s">{{ form.public_approval_summary.label }}</span>
+                {{ form.public_approval_summary }}
+                <div id="update_{{ forloop.counter }}-info"
+                     class="govuk-hint govuk-character-count__message"
+                     aria-live="polite">
+                </div>
+            </div>
+        </div>
+
+        <input type="submit" value="Save" class="govuk-button">
+        <a href="{% url 'barriers:public_barrier_detail' object.id %}" class="form-cancel">Cancel</a>
+    </form>
+
+{% endblock %}

--- a/templates/barriers/public_barriers/detail.html
+++ b/templates/barriers/public_barriers/detail.html
@@ -49,322 +49,324 @@
 
 {% block page_content %}
 
+    {% if messages %}
+        {% for message in messages %}
+            <div class="govuk-notification-banner govuk-notification-banner--success govuk-!-margin-bottom-4 govuk-!-padding-bottom-0" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+                <div class="govuk-notification-banner__header govuk-notification-banner--success__header">
+                    <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                        Success
+                    </h2>
+                </div>
+                <div class="govuk-notification-banner--success__content">
+                    <h3 class="govuk-notification-banner__heading">
+                        {{ message.extra_tags }}
+                    </h3>
+                    <p class="govuk-body govuk-!-margin-bottom-0">
+                        {{ message }}
+                    </p>
+                </div>
+            </div>
+        {% endfor %}
+    {% endif %}
+
     {% include 'barriers/partials/barrier_tabs.html' with active='public' %}
 
+    <!-- Left Content Panel -->
     <section class="summary-group">
-        <h2 class="summary-group__heading">Public view: {{ public_barrier.public_status_text }}
-            {% if public_barrier.ready_text %}<span class="summary-group__subheading">{{ public_barrier.ready_text }}</span>{% endif %}
-        </h2>
+        <h2 class="summary-group-public-view__heading">Prepare for publication</h2>
 
-        {% if public_barrier.public_view_status == 20 %}
-            <div class="public-barrier-approved-warning">
-                <div class="govuk-warning-text govuk-!-margin-bottom-2">
-                    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-
-
-                    <span class="govuk-warning-text__assistive">Warning</span> <strong class="govuk-warning-text__text">Updating the public view status to ‘allowed’ does not mean the barrier will be published.</strong>
-                </div>
-                <div class="public-barrier-approved-warning__body">
-                    <p>The barrier will only be published once it has gone through quality assurance checks by BTR, Post, OGDs, DAs, HMTCs and the content team.</p>
-
-                    <p>Choosing the option “allowed, it can be viewed by the public” confirms that the barrier will be viewable by the public once it has been published.</p>
-
-                    <p>You can check the progress of these quality assurance checks in the “Public view” tab on the barrier’s page.</p>
-
-                </div>
+        <!-- Public Eligibility Section -->
+        <div name="public-eligibility-box" class="public-view-information-box {% if barrier.public_eligibility is None %}public-view-information-box__notset{% endif %}">
+            <div class="govuk-summary-list__row">
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-3">Should this barrier be made public on GOV.UK once it has been approved?</h3>
             </div>
-        {% endif %}
-
-        {% if public_barrier.first_published_on %}
-            <div class="publish-dates">
-                {% if public_barrier.last_published_on == public_barrier.first_published_on %}
-                    <p class="publish-dates__date">Published on {{ public_barrier.last_published_on|date:"j F Y" }} at {{ public_barrier.last_published_on|time:"g:iA"|lower }} (GMT)</p>
+            {% if barrier.public_eligibility is None %}
+                <!-- Public eligibility not set. Show link to set eligibility.-->
+                <a href="{% url 'barriers:edit_public_eligibility' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Barrier publication status</a>
+            {% else %}
+                <!-- Public eligibility set. Show alternate content depending on its value.-->
+                {% if barrier.public_eligibility is True %}
+                    <!-- Public eligibility set to allowed. Show confirmation of status and link to edit eligibility.-->
+                    <p class="govuk-body govuk-!-margin-bottom-2">Yes</p>
+                    <a href="{% url 'barriers:edit_public_eligibility' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Edit</a>
                 {% else %}
-                    <p class="publish-dates__date publish-dates__date--first">First published on {{ public_barrier.first_published_on|date:"j F Y" }} at {{ public_barrier.first_published_on|time:"g:iA"|lower }} (GMT)</p>
-                    {% if not public_barrier.unpublished_on %}
-                        <p class="publish-dates__date">Last published on {{ public_barrier.last_published_on|date:"j F Y" }} at {{ public_barrier.last_published_on|time:"g:iA"|lower }} (GMT)</p>
-                    {% endif %}
+                    <!-- Public eligibility set to not allowed. Show confirmation of status, the given reason and a link to edit eligibility.-->
+                    <p class="govuk-body govuk-!-margin-bottom-2">No</p>
+                    <p class="govuk-body govuk-!-margin-bottom-2"><span class="govuk-!-font-weight-bold">Reason:</span> {{ barrier.public_eligibility_summary }} </p>
+                    <a href="{% url 'barriers:edit_public_eligibility' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Edit</a>
                 {% endif %}
-                {% if not public_barrier.is_published and public_barrier.unpublished_on %}
-                    <p class="publish-dates__date">Unpublished on {{ public_barrier.unpublished_on|date:"j F Y" }} at {{ public_barrier.unpublished_on|time:"g:iA"|lower }} (GMT)</p>
-                {% endif %}
+            {% endif %}
+        </div>
+
+        <!-- Public Title & Summary Section -->
+        <div name="public-title-summary-box" class="public-view-information-box {% if not barrier.public_eligibility %}public-view-information-box__notset{% endif %}">
+            <div class="govuk-summary-list__row">
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-3">Public title and summary</h3>
             </div>
-        {% endif %}
-
-        {% if barrier.public_eligibility and public_barrier.unpublished_changes %}
-            {% include "partials/warning.html" with warning_text="There are unpublished changes" modifier="small" extra_classes="publish-update-warning" %}
-        {% endif %}
-
-        {% if current_user|has_permission:"change_barrier_public_eligibility" and not current_user|has_permission:"change_publicbarrier" %}
-            <a href="{% url 'barriers:edit_public_eligibility' barrier.id %}" class="govuk-button govuk-button--secondary govuk-!-margin-bottom-3 govuk-!-margin-top-5">Update public view status</a>
-        {% endif %}
-
-        <dl class="summary-group__list">
-            <dt class="summary-group__list__key">Public title</dt>
-            <dd class="summary-group__list__value">
-                {% if barrier.public_eligibility and public_barrier.internal_title_changed %}
-                    {% include "partials/warning.html" with warning_text="Internal title has changed" modifier="small" extra_classes="govuk-!-margin-bottom-0" %}
-                {% endif %}
-                {% if public_barrier.title %}
-                    {% if barrier.public_eligibility and public_barrier.latest_published_version.title and public_barrier.latest_published_version.title != public_barrier.title %}
-                        <div class="public-barrier__published-value">{{ public_barrier.latest_published_version.title }}</div>
-
-                        <div class="public-barrier__current-value-container">
-                            <h3 class="public-barrier__current-value-heading">New public title - not yet published</h3>
-                            <p class="public-barrier__current-value">{{ public_barrier.title }}</p>
-                            {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                                <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_title' barrier.id %}">Edit</a>
-                            {% endif %}
-                        </div>
-                    {% else %}
-                        {{ public_barrier.title }}
-                        {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                            <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_title' barrier.id %}">Edit</a>
-                        {% endif %}
-                    {% endif %}
+            {% if not barrier.public_eligibility %}
+                <!-- Public eligibility not set. Block title and summary entry. -->
+                <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">You cannot add this information until you decide if this barrier should be made public on GOV.UK.</p>
+            {% else %}
+                <!-- Public eligibility set. Show links to add/edit public title and summary. -->
+                {% if not public_barrier.title %}
+                    <!-- Public title not set. Show link to public title entry only. -->
+                    <p class="govuk-body"><a href="{% url 'barriers:edit_public_barrier_title' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Public title</a></p>
                 {% else %}
-                    {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                        <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_title' barrier.id %}">Add public title</a>
-                    {% else %}
-                        {% include "partials/warning.html" with warning_text="Public title has not been created" modifier="small" extra_classes="govuk-!-margin-bottom-0 govuk-!-margin-top-2" %}
+                    <!-- Public title set. Show current public title and edit link. -->
+                    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">Public title</p>
+                    <p class="govuk-body govuk-!-margin-bottom-2">{{ public_barrier.title }}</p>
+                    {% if public_barrier.public_view_status == 20 %}
+                        <!-- Edit button only shown when in Allowed status-->
+                        <p class="govuk-body"><a href="{% url 'barriers:edit_public_barrier_title' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Edit</a></p>
                     {% endif %}
                 {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Public summary</dt>
-            <dd class="summary-group__list__value">
-                {% if barrier.public_eligibility and public_barrier.internal_summary_changed %}
-                    {% include "partials/warning.html" with warning_text="Internal summary has changed" modifier="small" extra_classes="govuk-!-margin-bottom-0" %}
-                {% endif %}
-                {% if public_barrier.summary %}
-                    {% if barrier.public_eligibility and public_barrier.latest_published_version.summary and public_barrier.latest_published_version.summary != public_barrier.summary %}
-                        <div class="public-barrier__published-value">{{ public_barrier.latest_published_version.summary|linebreaksbr }}</div>
-
-                        <div class="public-barrier__current-value-container">
-                            <h3 class="public-barrier__current-value-heading">New public summary - not yet published</h3>
-                            <p class="public-barrier__current-value">{{ public_barrier.summary|linebreaksbr }}</p>
-                            {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                                <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_summary' barrier.id %}">Edit</a>
-                            {% endif %}
-                        </div>
-                    {% else %}
-                        {{ public_barrier.summary|linebreaksbr }}
-                        {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                            <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_summary' barrier.id %}">Edit</a>
-                        {% endif %}
-                    {% endif %}
+                {% if not public_barrier.summary %}
+                    <!-- Public summary not set. Show link to public summary entry only. -->
+                    <p class="govuk-body"><a href="{% url 'barriers:edit_public_barrier_summary' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Public summary</a></p>
                 {% else %}
-                    {% if barrier.public_eligibility and current_user|has_permission:"change_publicbarrier" %}
-                        <a class="summary-group__list__value__edit" href="{% url 'barriers:edit_public_barrier_summary' barrier.id %}">Add public summary</a>
-                    {% else %}
-                        {% include "partials/warning.html" with warning_text="Public summary has not been created" modifier="small" extra_classes="govuk-!-margin-bottom-0 govuk-!-margin-top-2" %}
+                    <!-- Public summary set. Show current public summary and edit link. -->
+                    <p class="govuk-body govuk-!-font-weight-bold govuk-!-margin-bottom-0">Public summary</p>
+                    <p class="govuk-body govuk-!-margin-bottom-2">{{ public_barrier.summary }}</p>
+                    {% if public_barrier.public_view_status == 20 %}
+                        <!-- Edit button only shown when in Allowed status-->
+                        <p class="govuk-body"><a href="{% url 'barriers:edit_public_barrier_summary' barrier.id countdown %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Edit</a></p>
                     {% endif %}
                 {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Public ID</dt>
-            <dd class="summary-group__list__value">
-                {% if public_barrier.first_published_on %}
-                    {{ public_barrier.public_id }}
-                {% else %}
-                    A public ID will appear once published.
-                {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Resolved</dt>
-            <dd class="summary-group__list__value">
-                {% if public_barrier.internal_is_resolved_changed or public_barrier.internal_status_date_changed and public_barrier.first_published_on %}
-                    <span class="diff__del diff__del--block">
-                        {{ public_barrier.latest_published_version.is_resolved_text }}
-                    </span>
-                    <span class="diff__ins diff__ins--block">
-                        {{ public_barrier.internal_is_resolved_text }}
-                    </span>
-                {% else %}
-                    {{ public_barrier.internal_is_resolved_text }}
-                {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Date reported</dt>
-            <dd class="summary-group__list__value">
-                {{ public_barrier.reported_on|date:"j F Y" }}
-            </dd>
-
-            <dt class="summary-group__list__key">Location</dt>
-            <dd class="summary-group__list__value">
-                {% if public_barrier.internal_location_changed and public_barrier.first_published_on %}
-                    <span class="diff__del diff__del--block">{{ public_barrier.latest_published_version.location }}</span>
-                    <span class="diff__ins diff__ins--block">{{ public_barrier.internal_location }}</span>
-                {% else %}
-                    {{ public_barrier.internal_location }}
-                {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Sector</dt>
-            <dd class="summary-group__list__value">
-                {% if public_barrier.internal_any_sectors_changed and public_barrier.first_published_on %}
-                    {% if public_barrier.latest_published_version.sector_names %}
-                        <span class="diff__del diff__del--block">{{ public_barrier.latest_published_version.sector_names|join:", " }}</span>
-                    {% endif %}
-                    {% if public_barrier.internal_sector_names %}
-                        <span class="diff__ins diff__ins--block">{{ public_barrier.internal_sector_names|join:", " }}</span>
-                    {% endif %}
-                {% else %}
-                    {% if public_barrier.internal_sector_names %}
-                        {{ public_barrier.internal_sector_names|join:", " }}
-                    {% else %}
-                        Not selected, add on main barrier tab.
-                    {% endif %}
-                {% endif %}
-            </dd>
-
-            <dt class="summary-group__list__key">Category</dt>
-            <dd class="summary-group__list__value">
-                {% if public_barrier.internal_categories_changed and public_barrier.first_published_on %}
-                    {% if public_barrier.latest_published_version.category_titles %}
-                        <span class="diff__del diff__del--block">{{ public_barrier.latest_published_version.category_titles|join:", " }}</span>
-                    {% endif %}
-                    {% if public_barrier.internal_category_titles %}
-                        <span class="diff__ins diff__ins--block">{{ public_barrier.internal_category_titles|join:", " }}</span>
-                    {% endif %}
-                {% else %}
-                    {% if public_barrier.internal_category_titles %}
-                        {{ public_barrier.internal_category_titles|join:", " }}
-                    {% else %}
-                        Not selected, add on main barrier tab.
-                    {% endif %}
-                {% endif %}
-            </dd>
-        </dl>
-
-        <form action="" method="post">
-            {% csrf_token %}
-
-            {% if public_barrier.is_eligible or public_barrier.is_unpublished %}
-                {% if current_user|has_permission:"mark_barrier_as_ready_for_publishing" %}
+                <!-- Button control to move public barrier status -->
+                {% if public_barrier.public_view_status == 20 %}
                     {% if public_barrier.title and public_barrier.summary %}
-                        {% if public_barrier.unpublished_changes %}
-                            <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="mark-as-ready">Mark changes as ready to publish</button>
-                            {% if public_barrier.internal_title_changed or public_barrier.internal_summary_changed %}
-                                <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="ignore-changes">Confirm changes</button>
-                            {% endif %}
-                        {% else %}
-                            <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="mark-as-ready">Mark as ready to publish</button>
-                        {% endif %}
-                    {% else %}
-                        <button disabled="disabled" aria-disabled="true" class="govuk-button publishing-button disabled" data-module="govuk-button" name="action" value="mark-as-ready">Mark as ready to publish</button>
+                    <!-- Button to submit for approval only shown when in Allowed status, and has a title and summary set -->
+                        <form action="" method="POST">
+                            {% csrf_token %}
+                            <button name="action" value="submit-for-approval" class="govuk-button" tabindex="2">Submit for approval</button>
+                        </form>
                     {% endif %}
+                {% elif public_barrier.public_view_status == 70 %}
+                    <!-- Button to roll back submission for approval only shown when in Awaiting Approval status-->
+                    <form action="" method="POST">
+                        {% csrf_token %}
+                        <button name="action" value="remove-for-approval" class="govuk-button govuk-button--secondary" tabindex="2">Remove for approval</button>
+                    </form>
                 {% endif %}
             {% endif %}
+        </div>
 
-            {% if public_barrier.is_ready %}
-                {% if current_user|has_permission:"publish_barrier" %}
-                    <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="publish">Publish{% if public_barrier.first_published_on and not public_barrier.unpublished_on %} update{% endif %}</button>
+        <!-- Approvals Section -->
+        <div class="public-view-information-box {% if public_barrier.public_view_status == 10 or public_barrier.public_view_status == 20 or not barrier.public_eligibility %} public-view-information-box__notset {% endif %}">
+            <div class="govuk-summary-list__row">
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-3">Approvals</h3>
+            </div>
+            {% if public_barrier.public_view_status == 20 or not barrier.public_eligibility %}
+                <!-- Public title and barrier not set. Show reason for blocking approval step. -->
+                <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">This barrier cannot be approved until the publication status is set to 'allowed' and it has a public title and summary</p>
+            {% elif public_barrier.public_view_status == 30 %}
+                <!-- Public barrier is approved. Show detail of confirmation. -->
+                <p class="govuk-body">The barrier has been approved by: {{ approver_name }}</p>
+                <p class="govuk-body">They have checked it with the following people or organisations:</p>
+                <ul class="govuk-lis govuk-list--bullet govuk-list--spaced govuk-!-margin-bottom-0">
+                    <li class="govuk-body">Market Access Regional Coordinators </li>
+                    <li class="govuk-body">BTR Regional Teams </li>
+                    {% for item in barrier.government_organisations %}
+                        <li class="govuk-body">{{ item.name }}</li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <!-- Public title and barrier set. Show list of bodies which are being contacted by approver for approval. -->
+                {% if user_role == "General user" %}
+                    <!-- General users message for section -->
+                    <p class="govuk-body">The approver is reviewing this barrier with the following people:</p>
+                {% else %}
+                    <!-- Approver/Publisher users message for section -->
+                    <p class="govuk-body">As the approver of this barrier, you need to confirm you have checked it with the following people or organisations:</p>
                 {% endif %}
-                {% if current_user|has_permission:"mark_barrier_as_ready_for_publishing" %}
-                    <button class="govuk-button publishing-button govuk-button--secondary" data-module="govuk-button" name="action" value="mark-as-in-progress">Mark as in progress</button>
+                <ul class="govuk-lis govuk-list--bullet govuk-list--spaced govuk-!-margin-bottom-0">
+                    <li class="govuk-body">Market Access Regional Coordinators </li>
+                    <li class="govuk-body">BTR Regional Teams </li>
+                    {% for item in barrier.government_organisations %}
+                        <li class="govuk-body">{{ item.name }}</li>
+                    {% endfor %}
+                </ul>
+                {% if user_role == "General user" %}
+                    <!-- General users display approval process message -->
+                    <p class="govuk-body">They will then confirm if they are happy for the barrier to made public on GOV.UK.</p>
+                {% endif %}
+                {% if user_role == "Approver" or user_role == "Publisher" %}
+                    <!-- Button to edit list of approver orgs only displays for approvers and publishers-->
+                    <p class="govuk-body"><a href="{% url 'barriers:edit_gov_orgs' barrier.id %}" class="govuk-link--no-visited-state govuk-!-font-size-19">Edit list</a></p>
                 {% endif %}
             {% endif %}
-
-            {% if public_barrier.is_published and current_user|has_permission:"publish_barrier" %}
-                {% if public_barrier.internal_title_changed or public_barrier.internal_summary_changed %}
-                    <button disabled="disabled" aria-disabled="true"  class="govuk-button publishing-button" data-module="govuk-button" name="action" value="publish">Publish update</button>
-                    <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="ignore-changes">Accept changes</button>
-                {% elif public_barrier.unpublished_changes %}
-                    <button class="govuk-button publishing-button" data-module="govuk-button" name="action" value="mark-as-ready">Mark changes as ready to publish</button>
-                {% endif %}
-                <button class="govuk-button govuk-button--secondary publishing-button" data-module="govuk-button" name="action" value="unpublish">Unpublish</button>
+            {% if user_role == "Approver" and public_barrier.public_view_status == 70 or user_role == "Publisher" and public_barrier.public_view_status == 70 %}
+                <!-- Button to confirm approval only shown when user is either a approver or publisher and the status is Awaiting Approval -->
+                <a href="{% url 'barriers:approve_public_barrier_confirmation' barrier.id countdown %}" class="govuk-button">Approve barrier</a>
             {% endif %}
-        </form>
+            {% if user_role == "Approver" and public_barrier.public_view_status == 30 or user_role == "Publisher" and public_barrier.public_view_status == 30 %}
+                <!-- Button to confirm approval only shown when user is either a approver or publisher and the status is Awaiting Approval -->
+                <form action="" method="POST">
+                    {% csrf_token %}
+                    <button name="action" value="remove-for-publishing" class="govuk-button govuk-button--secondary" tabindex="2">Revert approval</button>
+                </form>
+            {% endif %}
+        </div>
 
-        {% if not public_barrier.is_published and current_user|has_permission:"change_publicbarrier" %}
-            <a href="{% url 'barriers:edit_public_eligibility' barrier.id %}" class="govuk-button govuk-button--secondary">Update public view status</a>
-        {% endif %}
+        <!-- Publishing Section -->
+
+        <div class="public-view-information-box {% if public_barrier.public_view_status == 70 or public_barrier.public_view_status == 10 or public_barrier.public_view_status == 20 or not barrier.public_eligibility %}public-view-information-box__notset{% endif %}">
+            <div class="govuk-summary-list__row">
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-3">Publishing</h3>
+            </div>
+            {% if user_role != "Publisher" %}
+                <!-- Approvers and general users section -->
+                {% if public_barrier.public_view_status == 30 %}
+                    <!-- The barrier has a Awaiting publishing status and is being revied by publisher -->
+                    <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">The GOV.UK team are reviewing the content for this approved barrier.</p>
+                    <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">They will update the status to 'published' once it is live. You will then be able to view the barrier by visiting <a href="https://www.check-international-trade-barriers.service.gov.uk/" target="_blank" class="govuk-link--no-visited-state govuk-!-font-size-19">check international trade barriers (opens in new tab)</a></p>
+                {% elif public_barrier.public_view_status == 40 %}
+                    <!-- The barrier has been published -->
+                    <p class="govuk-body">This barrier was published by {{publisher_name}} on {{published_date}}.</p>
+                    <p class="govuk-body">If you want to make changes to this barrier you will need to set the status to unpublished and check it with the approver.</p>
+                {% else %}
+                    <!-- The barrier has not reached the stage this section becomes active -->
+                    <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">The GOV.UK team will publish the barrier if all the information is complete and it has been approved.</p>
+                {% endif %}
+            {% else %}
+                <!-- Publishers section -->
+                {% if public_barrier.public_view_status == 30 or public_barrier.public_view_status == 50 %}
+                    <!-- The barrier needs checking by the publisher -->
+                    <p class="govuk-body">When you have completed your content checks you can publish this barrier.</p>
+                    <a href="{% url 'barriers:publish_public_barrier_confirmation' barrier.id %}" class="govuk-button">Publish</a>
+                {% elif public_barrier.public_view_status == 40 %}
+                    <!-- The barrier is published -->
+                    <p class="govuk-body">This barrier was published by {{publisher_name}} on {{published_date}}.</p>
+                    <p class="govuk-body">If you want to make changes to this barrier you will need to set the status to unpublished and check it with the approver.</p>
+                    <a href="{% url 'barriers:unpublish_public_barrier_confirmation' barrier.id %}" class="govuk-button govuk-button--secondary">Unpublish</a>
+                {% else %}
+                    <!-- The barrier is not ready for publishing-->
+                    <p class="govuk-body govuk-hint govuk-!-margin-bottom-2">The GOV.UK team will publish the barrier if all the information is complete and it has been approved.</p>
+                {% endif %}
+            {% endif %}
+        </div>
+
+        <!-- Other Barrier Details Section -->
+        <div class="public-view-information-box govuk-!-margin-bottom-0 govuk-!-padding-bottom-0">
+            <details class="govuk-details" data-module="govuk-details" open="">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                        Other barrier details
+                    </span>
+                </summary>
+                <div class="govuk-details__text">
+                    <dl class="summary-group__list">
+                        <dt class="summary-group__list__key">Public ID</dt>
+                        <dd class="summary-group__list__value">
+                            {% if public_barrier.first_published_on %}
+                                {{ public_barrier.public_id }}
+                            {% else %}
+                                A public ID will appear once published.
+                            {% endif %}
+                        </dd>
+                        <dt class="summary-group__list__key">Resolved</dt>
+                        <dd class="summary-group__list__value">
+                            {{ public_barrier.internal_is_resolved_text }}
+                        </dd>
+                        <dt class="summary-group__list__key">Date reported</dt>
+                        <dd class="summary-group__list__value">
+                            {{ public_barrier.reported_on|date:"j F Y" }}
+                        </dd>
+                        <dt class="summary-group__list__key">Location</dt>
+                        <dd class="summary-group__list__value">
+                            {{ public_barrier.internal_location }}
+                        </dd>
+                        <dt class="summary-group__list__key">Sector</dt>
+                        <dd class="summary-group__list__value">
+                            {% if public_barrier.internal_sector_names %}
+                                {{ public_barrier.internal_sector_names|join:", " }}
+                            {% else %}
+                                Not selected, <a href="{% url 'barriers:barrier_detail' barrier.id %}">add on main barrier tab</a>.
+                            {% endif %}
+                        </dd>
+                        <dt class="summary-group__list__key">Category</dt>
+                        <dd class="summary-group__list__value">
+                            {% if public_barrier.internal_category_titles %}
+                                {{ public_barrier.internal_category_titles|join:", " }}
+                            {% else %}
+                                Not selected, <a href="{% url 'barriers:barrier_detail' barrier.id %}">add on main barrier tab</a>.
+                            {% endif %}
+                        </dd>
+                    </dl>
+                </div>
+            </details>
+        </div>
     </section>
 
+    <!-- Right Content Panel -->
     <section class="barrier-content">
+
+        <!-- Publication Status Section -->
+        <h2 class="section-heading govuk-!-margin-bottom-0">Barrier publication status</h2>
+        <div class="public-view-status-box {% if public_barrier.public_view_status == 40 %} public-view-status-box__published {% else %} public-view-status-box__inprogress {% endif %}">
+            <h2 class="public-view-status-box__heading govuk-!-margin-bottom-0 govuk-!-margin-top-0">
+                {% if barrier.public_eligibility is None %}
+                    <!-- Public barrier status is Unknown -->
+                    Set a publication status
+                {% elif barrier.public_eligibility is False %}
+                    <!-- Public barrier status is Not Allowed -->
+                    {% if user_role == "General user" %}
+                        This barrier will not be published on GOV.UK
+                    {% else %}
+                        This barrier does not need approval
+                    {% endif %}
+                {% else %}
+                    {% if public_barrier.public_view_status == 20 %}
+                        <!-- Public barrier status is Allowed -->
+                        This barrier is not ready for approval
+                    {% elif public_barrier.public_view_status == 70 %}
+                        <!-- Public barrier status is Awaiting Approval -->
+                        This barrier is awaiting approval
+                    {% elif public_barrier.public_view_status == 30 or public_barrier.public_view_status == 50 %}
+                        <!-- Public barrier status is Awaiting Publishing -->
+                        GOV.UK content checks are needed
+                    {% elif public_barrier.public_view_status == 40 %}
+                        <!-- Public barrier status is Published -->
+                        This barrier has been published
+                    {% endif %}
+                {% endif %}
+            </h2>
+            <p class="govuk-!-margin-0 govuk-!-padding-top-2">
+                {% if barrier.public_eligibility is None %}
+                    <!-- Public barrier status is Unknown -->
+                    To start the approval process to decide if this barrier can be made public on GOV.UK, first update the barrier publication status to 'allowed', and add a public title and summary.
+                {% elif barrier.public_eligibility is False %}
+                    <!-- Public barrier status is Not Allowed -->
+                    {% if user_role == "General user" or user_role == "Publisher" %}
+                        To start the approval process to make this barrier public on GOV.UK, update the barrier publication status to 'allowed', and add a public title and summary.
+                    {% else %}
+                        You do not need to approve this barrier unless the barrier publication status is updated to 'allowed', and it includes a public title and summary.
+                    {% endif %}
+                {% else %}
+                    {% if public_barrier.public_view_status == 20 %}
+                        <!-- Public barrier status is Allowed -->
+                        This barrier cannot be approved until the public title and summary have been added.
+                        This needs to be done within the next {{ countdown }} days, along with a review from the approver, and the GOV.UK publishing team.
+                    {% elif public_barrier.public_view_status == 70 %}
+                        <!-- Public barrier status is Awaiting Approval -->
+                        Once it has been approved, the barrier will be sent to the GOV.UK team for final content checks.
+                        This needs to be done within the next {{ countdown }} days.
+                    {% elif public_barrier.public_view_status == 30 or public_barrier.public_view_status == 50 %}
+                        <!-- Public barrier status is Awaiting Publishing -->
+                        Only a member of the GOV.UK publishing team can complete the content checks.
+                        This needs to be done within the next {{ countdown }} days. The barrier can then be published.
+                    {% elif public_barrier.public_view_status == 40 %}
+                        <!-- Public barrier status is Published -->
+                        You can view the barrier on GOV.UK by visiting <a class="govuk-link" href="https://www.check-international-trade-barriers.service.gov.uk/" target="_blank">Check International Trade Barriers (opens in new tab).</a>
+                        For more details see the barrier information and notes on the public view tab.
+                    {% endif %}
+                {% endif %}
+            </p>
+        </div>
+
+        <!-- Public Barrier Notes Section -->
         <h2 class="section-heading govuk-!-margin-bottom-0">Internal notes and updates</h2>
         <span class="govuk-caption-m govuk-!-margin-bottom-6">These are not shown to the public.</span>
-
-        {% if public_barrier.light_touch_reviews.enabled %}
-            <div class="review-progress-checkboxes">
-                <h3>Review progress</h3>
-                <p class="description">Keep track of outstanding approvals</p>
-
-
-                <form class="govuk-checkboxes" id="tags" action="{% url 'barriers:edit_public_barrier_reviews' barrier.id %}" method="get">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend filter-items__label filter-group__label visually-hidden">
-                            Review Progress
-                        </legend>
-                        {% if public_barrier.title and public_barrier.summary %}
-                            <div class="checkbox-option">
-                                <div class="govuk-checkboxes__item">
-
-                                    <input class="govuk-checkboxes__input"
-                                           name="content_approval"
-                                           onChange="this.form.submit()"
-                                           type="checkbox"
-                                           {% if public_barrier.light_touch_reviews.content_team_approval %}checked{% endif %}>
-                                    <label class="govuk-label govuk-checkboxes__label">
-                                        Content team</label>
-                                    {% if public_barrier.light_touch_reviews.has_content_changed_since_approval %}<span class="checkbox-note">Edited since last content review</span>{% endif %}
-                                </div>
-                            </div>
-                        {% else %}
-                            <div class="checkbox-option">
-                                <p class="add-approval-link">
-                                    <span>Public barrier has no title or summary content to review</span>
-                                </p>
-                            </div>
-                        {% endif %}
-                        {% if public_barrier.light_touch_reviews.hm_trade_commissioner_approval_enabled %}
-                            <div class="checkbox-option">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input"
-                                           name="hm_trade_comm_approval"
-                                           onChange="this.form.submit()"
-                                           type="checkbox"
-                                           {% if public_barrier.light_touch_reviews.hm_trade_commissioner_approval %}checked{% endif %}>
-                                    <label class="govuk-label govuk-checkboxes__label">HM Trade Commissioner</label>
-                                </div>
-                            </div>
-                        {% else %}
-                            <div class="checkbox-option">
-                                <p class="add-approval-link">
-                                    <a href="{% url 'barriers:enable_hm_trade_commissioner_approvals' barrier.id %}?enabled=1">Add HM Trade Commissioner</a>
-                                </p>
-                            </div>
-                        {% endif %}
-                        {% for government_organisation in barrier.government_organisations %}
-                            <div class="checkbox-option">
-                                <div class="govuk-checkboxes__item">
-                                    <input class="govuk-checkboxes__input"
-                                           name="organisation_approval__{{ government_organisation.id }}"
-                                           onChange="this.form.submit()"
-                                           type="checkbox"
-                                           {% if government_organisation.id in public_barrier.light_touch_reviews.government_organisation_approvals %}checked{% endif %}>
-                                    <label class="govuk-label govuk-checkboxes__label">{{ government_organisation.name }}</label>
-                                    <a href="{% url 'barriers:edit_gov_orgs' barrier.id %}?return_to=public_barrier_detail" class="remove">Edit</a>
-                                </div>
-                            </div>
-                        {% empty %}
-                        {% endfor %}
-                        {% if not public_barrier.light_touch_reviews.hm_trade_commissioner_approval_enabled %}
-                        {% endif %}
-                        <div class="checkbox-option">
-                            <p class="add-approval-link">
-                                <a href="{% url 'barriers:edit_gov_orgs' barrier.id %}?return_to=public_barrier_detail">Add government organisation</a>
-                            </p>
-                        </div>
-                    </fieldset>
-                    <noscript>
-                        <br/>
-                        <input type="submit" class="govuk-button button--primary" value="Save"/>
-                    </noscript>
-                </form>
-            </div>
-        {% endif %}
 
         {% if add_note %}
             <div class="interaction-panel">

--- a/templates/barriers/public_barriers/publish_confirmation.html
+++ b/templates/barriers/public_barriers/publish_confirmation.html
@@ -1,0 +1,23 @@
+{% extends "barriers/edit/base.html" %}
+
+{% block page_title %}{{ block.super }} Confirm Public Barrier Approval {% endblock %}
+
+{% block page_content %}
+
+    <form action="" novalidate method="POST" class="restrict-width">
+        {% csrf_token %}
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">Confirm you want to publish this barrier on GOV.UK</h1>
+        </legend>
+
+        <p class="govuk-body">By choosing to publish this barrier, you confirm that you want it to be made public on <a href="https://www.check-international-trade-barriers.service.gov.uk/" target="_blank" class="govuk-link--no-visited-state govuk-!-font-size-19">check international trade barriers (opens in new tab)</a>.</p>
+
+        <p class="govuk-body">
+            {% csrf_token %}
+            <input type="submit" value="Confirm" class="govuk-button">
+            <a href="{% url 'barriers:public_barrier_detail' object.id %}" class="form-cancel">Cancel</a>
+        </p>
+    </form>
+
+{% endblock %}

--- a/templates/barriers/public_barriers/summary.html
+++ b/templates/barriers/public_barriers/summary.html
@@ -1,6 +1,6 @@
 {% extends "barriers/edit/base.html" %}
 
-{% block page_title %}{{ block.super }} - Publish summary{% endblock %}
+{% block page_title %}{{ block.super }} Edit Public Summary {% endblock %}
 
 {% block body_script %}
     <script nonce="{{request.csp_nonce}}">
@@ -10,27 +10,48 @@
     </script>
 {% endblock %}
 
-{% block back_link %}
-    <a href="{% url 'barriers:public_barrier_detail' object.id %}" class="govuk-back-link ma-back-link">Back</a>
-{% endblock %}
-
 {% block page_content %}
 
-    {% form_error_banner form %}
-
-    <form action="" method="POST" class="restrict-width">
+    <form action="" novalidate method="POST" class="restrict-width">
         {% csrf_token %}
 
-        {% include "partials/forms/textarea.html" with field=form.summary label_classes="govuk-label--l" character_count=True %}
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">Public summary</h1>
+        </legend>
 
-        <details class="govuk-details" data-module="govuk-details">
+        {% form_error_banner form %}
+
+        <div id="{{ form.summary.name }}-form-group"
+             class="govuk-character-count"
+             data-module="character-count"
+             data-maxlength="1500">
+            <div class="{% form_group_classes form.summary.errors %}">
+                {% form_field_error form "summary" %}
+                <span id="{{ form.summary.name }}_hint" class="govuk-hint">{{ form.summary.help_text }}</span>
+                <div class="govuk-body">
+                    <a href='https://data-services-help.trade.gov.uk/market-access/how-guides/how-prepare-market-access-barrier-report-public-view/' target='_blank'>Find out how to write a public summary (opens in a new tab)</a>
+                </div>
+                {{ form.summary }}
+                <div id="update_{{ forloop.counter }}-info"
+                     class="govuk-hint govuk-character-count__message"
+                     aria-live="polite">
+                </div>
+            </div>
+        </div>
+
+        <details class="govuk-details govuk-!-margin-bottom-6">
             <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
-                    Internal summary for reference
+                    View internal title and summary
                 </span>
             </summary>
             <div class="govuk-details__text">
-                {{ barrier.summary|escape|linebreaksbr }}
+                <p class="govuk-body">
+                    <strong>Barrier title:</strong> {{ internal_title }}
+                </p>
+                <p class="govuk-body">
+                    <strong>Barrier description:</strong> {{ internal_summary }}
+                </p>
             </div>
         </details>
 

--- a/templates/barriers/public_barriers/title.html
+++ b/templates/barriers/public_barriers/title.html
@@ -1,6 +1,6 @@
 {% extends "barriers/edit/base.html" %}
 
-{% block page_title %}{{ block.super }} - Publish title{% endblock %}
+{% block page_title %}{{ block.super }} Edit Public Title {% endblock %}
 
 {% block body_script %}
     <script nonce="{{request.csp_nonce}}">
@@ -10,27 +10,48 @@
     </script>
 {% endblock %}
 
-{% block back_link %}
-    <a href="{% url 'barriers:public_barrier_detail' object.id %}" class="govuk-back-link ma-back-link">Back</a>
-{% endblock %}
-
 {% block page_content %}
 
-    {% form_error_banner form %}
-
-    <form action="" method="POST" class="restrict-width">
+    <form action="" novalidate method="POST" class="restrict-width">
         {% csrf_token %}
 
-        {% include "partials/forms/text_input.html" with field=form.title label_classes="govuk-label--l" %}
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">Public title</h1>
+        </legend>
 
-        <details class="govuk-details" data-module="govuk-details">
+        {% form_error_banner form %}
+
+        <div id="{{ form.title.name }}-form-group"
+             class="govuk-character-count"
+             data-module="character-count"
+             data-maxlength="150">
+            <div class="{% form_group_classes form.title.errors %}">
+                {% form_field_error form "title" %}
+                <span id="{{ form.title.name }}_hint" class="govuk-hint">{{ form.title.help_text }}</span>
+                <div class="govuk-body">
+                    <a href='https://data-services-help.trade.gov.uk/market-access/how-guides/how-prepare-market-access-barrier-report-public-view/' target='_blank'>Find out how to write a public title (opens in a new tab)</a>
+                </div>
+                {{ form.title }}
+                <div id="update_{{ forloop.counter }}-info"
+                     class="govuk-hint govuk-character-count__message"
+                     aria-live="polite">
+                </div>
+            </div>
+        </div>
+
+        <details class="govuk-details govuk-!-margin-bottom-6">
             <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
-                    Internal summary for reference
+                    View internal title and summary
                 </span>
             </summary>
             <div class="govuk-details__text">
-                {{ barrier.summary|escape|linebreaksbr }}
+                <p class="govuk-body">
+                    <strong>Barrier title:</strong> {{ internal_title }}
+                </p>
+                <p class="govuk-body">
+                    <strong>Barrier description:</strong> {{ internal_summary }}
+                </p>
             </div>
         </details>
 

--- a/templates/barriers/public_barriers/unpublish_confirmation.html
+++ b/templates/barriers/public_barriers/unpublish_confirmation.html
@@ -1,0 +1,46 @@
+{% extends "barriers/edit/base.html" %}
+
+{% block page_title %}{{ block.super }} Confirm Public Barrier Approval {% endblock %}
+
+{% block body_script %}
+    <script nonce="{{request.csp_nonce}}">
+        if( ma.components.CharacterCount ){
+            new ma.components.CharacterCount( '.govuk-character-count' );
+        }
+    </script>
+{% endblock %}
+
+{% block page_content %}
+
+    <form action="" novalidate method="POST" class="restrict-width">
+        {% csrf_token %}
+
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading">Confirm you want to remove this barrier on GOV.UK</h1>
+        </legend>
+
+        <p class="govuk-body">By choosing to remove this barrier, you confirm that you no longer want it to be made public on <a href="https://www.check-international-trade-barriers.service.gov.uk/" target="_blank" class="govuk-link--no-visited-state govuk-!-font-size-19">check international trade barriers (opens in new tab)</a>.</p>
+
+        <div id="{{ form.public_publisher_summary.name }}"
+             class="govuk-character-count"
+             data-module="character-count"
+             data-maxlength="500">
+            <div class="{% form_group_classes form.public_publisher_summary.errors %}">
+                {% form_field_error form "public_publisher_summary" %}
+                <span id="{{ form.public_publisher_summary.name }}_label" class="govuk-label govuk-label--s">{{ form.public_publisher_summary.label }}</span>
+                {{ form.public_publisher_summary }}
+                <div id="update_{{ forloop.counter }}-info"
+                     class="govuk-hint govuk-character-count__message"
+                     aria-live="polite">
+                </div>
+            </div>
+        </div>
+
+        <p class="govuk-body">
+            {% csrf_token %}
+            <input type="submit" value="Confirm" class="govuk-button">
+            <a href="{% url 'barriers:public_barrier_detail' object.id %}" class="form-cancel">Cancel</a>
+        </p>
+    </form>
+
+{% endblock %}

--- a/templates/reports/barrier_details_summary_wizard_step.html
+++ b/templates/reports/barrier_details_summary_wizard_step.html
@@ -88,7 +88,7 @@
             </div>
 
             <!-- Goods/services/hs-codes section -->
-            <div class="report-barrier-questions__section govuk-!-margin-bottom-0">
+            <div class="report-barrier-questions__section">
                 <h2 class="govuk-heading-m">Goods, services or investments affected</h2>
                 <div class="report-barrier-questions__question">
                     <h4 class="govuk-heading-s question-label">Export type</h4>
@@ -113,6 +113,38 @@
                     </div>
                 {% endfor %}
 
+            </div>
+
+            <!-- Barrier publication section -->
+            <div class="report-barrier-questions__section govuk-!-margin-bottom-0">
+                <h2 class="govuk-heading-m">Barrier publication</h2>
+                <div class="report-barrier-questions__question">
+                    <h4 class="govuk-heading-s question-label">Publishing</h4>
+                    <div class="answer">{{public_eligibility}}</div>
+                    <div class="edit-url"><a href="/reports/barrier-public-eligibility" class="govuk-link">Change</a></div>
+                </div>
+                {% if public_eligibility == "Cannot be published" %}
+                    <div class="report-barrier-questions__question">
+                        <h4 class="govuk-heading-s question-label">Reason</h4>
+                        <div class="answer">{{public_eligibility_summary}}</div>
+                        <div class="edit-url"><a href="/reports/barrier-public-eligibility" class="govuk-link">Change</a></div>
+                    </div>
+                {% else %}
+                    {% if public_title %}
+                        <div class="report-barrier-questions__question">
+                            <h4 class="govuk-heading-s question-label">Public title</h4>
+                            <div class="answer">{{public_title}}</div>
+                            <div class="edit-url"><a href="/reports/barrier-public-title" class="govuk-link">Change</a></div>
+                        </div>
+                    {% endif %}
+                    {% if public_summary %}
+                        <div class="report-barrier-questions__question">
+                            <h4 class="govuk-heading-s question-label">Public summary</h4>
+                            <div class="answer">{{public_summary}}</div>
+                            <div class="edit-url"><a href="/reports/barrier-public-summary" class="govuk-link">Change</a></div>
+                        </div>
+                    {% endif %}
+                {% endif %}
             </div>
 
             <!-- Confirm input to conmplete process -->

--- a/templates/reports/barrier_public_eligibility_wizard_step.html
+++ b/templates/reports/barrier_public_eligibility_wizard_step.html
@@ -1,37 +1,17 @@
-{% extends "barriers/edit/base.html" %}
-{% load render_bundle from webpack_loader %}
+{% extends "reports/barrier_wizard_step.html" %}
 
-{% block page_title %}{{ block.super }} Edit Publish Eligibility {% endblock %}
+{% block page_title %} Report A Barrier - Wizard Framework - Barrier Publication{% endblock %}
 
-{% block body_script %}
-    {% render_bundle 'main' 'js' 'REACT' %}
-    <!-- Import GDS Javascript components -->
-    <script nonce="{{request.csp_nonce}}">
-        document.addEventListener("DOMContentLoaded", function (event) {
-            ReactApp.GDSCheckboxes();
-        })
-        document.addEventListener("DOMContentLoaded", function (event) {
-            ReactApp.GDSRadios();
-        })
-        if( ma.components.CharacterCount ){
-            new ma.components.CharacterCount( '.govuk-character-count' );
-        }
-    </script>
-{% endblock %}
+{% block fields %}
+    <div class="govuk-form-group govuk-!-margin-0">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                    Barrier publication
+                </h1>
+            </legend>
 
-{% block page_content %}
-
-    <form action="" method="POST" class="restrict-width">
-        {% csrf_token %}
-
-        <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading">
-                Barrier publication
-            </h1>
-        </legend>
-
-        {% form_error_banner form %}
-        <div class="{% form_group_classes form.public_eligibility.errors %}">
+            {% form_error_banner form %}
 
             <div class="govuk-radios" data-module="govuk-radios">
                 <label class="govuk-label govuk-label--s" for="{{ form.public_eligibility.name }}">{{ form.public_eligibility.label }}</label>
@@ -59,17 +39,17 @@
                     <div class="govuk-radios__item">
                         <input class="govuk-radios__input"
                                id="{{ form.public_eligibility.id_for_label }}"
-                               name="public_eligibility"
+                               name="barrier-public-eligibility-public_eligibility"
                                type="radio"
                                value="{{ value }}"
-                               data-aria-controls="conditional-public_eligibility-{{value}}"
+                               data-aria-controls="conditional-public_eligibility-{{ value }}"
                                {% if form.public_eligibility.value == value %} checked="checked"{% endif %}>
                         <label class="govuk-label govuk-radios__label" for="{{ form.public_eligibility.id_for_label }}">
                             {{ name }}
                         </label>
                     </div>
                     {% if value == "no" %}
-                        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-public_eligibility-{{value}}">
+                        <div class="govuk-radios__conditional govuk-radios__conditional--hidden" id="conditional-public_eligibility-{{ value }}">
                             <div id="{{ form.public_eligibility_summary.name }}-form-group"
                                  class="govuk-character-count govuk-!-margin-0"
                                  data-module="character-count"
@@ -85,14 +65,11 @@
                             </div>
                         </div>
                     {% endif %}
+
                 {% endfor %}
             </div>
-        </div>
 
-        <div class="govuk-body govuk-!-margin-top-6">
-            <button class="govuk-button ">Confirm</button>
-            <a class="form-cancel" href="{% url 'barriers:public_barrier_detail' barrier.id %}">Cancel</a>
-        </div>
-    </form>
 
+        </fieldset>
+    </div>
 {% endblock %}

--- a/templates/reports/barrier_public_information_gate_wizard_step.html
+++ b/templates/reports/barrier_public_information_gate_wizard_step.html
@@ -1,0 +1,45 @@
+{% extends "reports/barrier_wizard_step.html" %}
+
+{% block page_title %} Report A Barrier - Wizard Framework - Barrier Publication Data Entry Choice{% endblock %}
+
+{% block fields %}
+    <div class="govuk-form-group govuk-!-margin-0">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">
+                    Barrier publication
+                </h1>
+            </legend>
+
+            {% form_error_banner form %}
+
+            <div class="govuk-radios" data-module="govuk-radios">
+                <label class="govuk-label govuk-label--s" for="{{ form.public_information.name }}">{{ form.public_information.label }}</label>
+                <div class="govuk-inset-text inset-banner">
+                    For a barrier to be published on GOV.UK, it must have a title and summary that are suitable for the public to read.<br><br>
+                    <a href='https://data-services-help.trade.gov.uk/market-access/how-guides/how-prepare-market-access-barrier-report-public-view/' target='_blank'>Find out how to write a public title and summary (opens in a new tab)</a>
+                </div>
+                <span class="govuk-hint">{{ form.public_information.help_text }}</span>
+
+                {% form_field_error form "public_information" %}
+
+                {% for value, name in form.fields.public_information.choices %}
+                    <div class="govuk-radios__item">
+                        <input class="govuk-radios__input"
+                               id="{{ form.public_information.id_for_label }}"
+                               name="barrier-public-information-gate-public_information"
+                               type="radio"
+                               value="{{ value }}"
+                               {% if form.public_information.value == value %} checked="checked"{% endif %}>
+                        <label class="govuk-label govuk-radios__label" for="{{ form.public_information.id_for_label }}">
+                            {{ name }}
+                        </label>
+                    </div>
+
+                {% endfor %}
+            </div>
+
+
+        </fieldset>
+    </div>
+{% endblock %}

--- a/templates/reports/barrier_public_summary_wizard_step.html
+++ b/templates/reports/barrier_public_summary_wizard_step.html
@@ -1,0 +1,54 @@
+{% extends "reports/barrier_wizard_step.html" %}
+{% load render_bundle from webpack_loader %}
+{% load report_urls %}
+{% block page_title %}Report A Barrier - Wizard Framework - Public Summary{% endblock %}
+{% block body_script %}
+    {% render_bundle 'main' 'js' 'REACT' %}
+    <script nonce="{{request.csp_nonce}}">
+        if( ma.components.CharacterCount ){
+            new ma.components.CharacterCount( '#{{ form.summary.name }}-form-group.govuk-character-count' );
+        }
+    </script>
+{% endblock %}
+{% block fields %}
+    <div class="govuk-form-group govuk-!-margin-0">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">Public summary</h1>
+            </legend>
+            {% form_error_banner form %}
+            <div id="{{ form.summary.name }}-form-group"
+                 class="govuk-character-count"
+                 data-module="character-count"
+                 data-maxlength="1500">
+                <div class="{% form_group_classes form.summary.errors %}">
+                    {% form_field_error form "summary" %}
+                    <span id="{{ form.summary.name }}_hint" class="govuk-hint">{{ form.summary.help_text }}</span>
+                    <div class="govuk-body">
+                        <a href='https://data-services-help.trade.gov.uk/market-access/how-guides/how-prepare-market-access-barrier-report-public-view/' target='_blank'>Find out how to write a public summary (opens in a new tab)</a>
+                    </div>
+                    {{ form.summary }}
+                    <div id="update_{{ forloop.counter }}-info"
+                         class="govuk-hint govuk-character-count__message"
+                         aria-live="polite">
+                    </div>
+                </div>
+            </div>
+            <details class="govuk-details govuk-!-margin-bottom-0">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                        View internal title and summary
+                    </span>
+                </summary>
+                <div class="govuk-details__text">
+                    <p class="govuk-body">
+                        <strong>Barrier title:</strong> {{ internal_title }}
+                    </p>
+                    <p class="govuk-body">
+                        <strong>Barrier description:</strong> {{ internal_summary }}
+                    </p>
+                </div>
+            </details>
+        </fieldset>
+    </div>
+{% endblock %}

--- a/templates/reports/barrier_public_title_wizard_step.html
+++ b/templates/reports/barrier_public_title_wizard_step.html
@@ -1,0 +1,54 @@
+{% extends "reports/barrier_wizard_step.html" %}
+{% load render_bundle from webpack_loader %}
+{% load report_urls %}
+{% block page_title %}Report A Barrier - Wizard Framework - Public Title{% endblock %}
+{% block body_script %}
+    {% render_bundle 'main' 'js' 'REACT' %}
+    <script nonce="{{request.csp_nonce}}">
+        if( ma.components.CharacterCount ){
+            new ma.components.CharacterCount( '#{{ form.title.name }}-form-group.govuk-character-count' );
+        }
+    </script>
+{% endblock %}
+{% block fields %}
+    <div class="govuk-form-group govuk-!-margin-0">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                <h1 class="govuk-fieldset__heading">Public title</h1>
+            </legend>
+            {% form_error_banner form %}
+            <div id="{{ form.title.name }}-form-group"
+                 class="govuk-character-count"
+                 data-module="character-count"
+                 data-maxlength="255">
+                <div class="{% form_group_classes form.title.errors %}">
+                    {% form_field_error form "title" %}
+                    <span id="{{ form.title.name }}_hint" class="govuk-hint">{{ form.title.help_text }}</span>
+                    <div class="govuk-body">
+                        <a href='https://data-services-help.trade.gov.uk/market-access/how-guides/how-prepare-market-access-barrier-report-public-view/' target='_blank'>Find out how to write a public title (opens in a new tab)</a>
+                    </div>
+                    {{ form.title }}
+                    <div id="update_{{ forloop.counter }}-info"
+                         class="govuk-hint govuk-character-count__message"
+                         aria-live="polite">
+                    </div>
+                </div>
+            </div>
+            <details class="govuk-details govuk-!-margin-bottom-0">
+                <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">
+                        View internal title and summary
+                    </span>
+                </summary>
+                <div class="govuk-details__text">
+                    <p class="govuk-body">
+                        <strong>Barrier title:</strong> {{ internal_title }}
+                    </p>
+                    <p class="govuk-body">
+                        <strong>Barrier description:</strong> {{ internal_summary }}
+                    </p>
+                </div>
+            </details>
+        </fieldset>
+    </div>
+{% endblock %}

--- a/templates/reports/barrier_wizard_step.html
+++ b/templates/reports/barrier_wizard_step.html
@@ -38,7 +38,9 @@
                 {% csrf_token %}
                 {{ wizard.management_form }}
                 {% block current_step %}
-                    <span class="govuk-caption-l">Section {{ wizard.steps.step1 }} of {{ wizard.steps.count }}</span>
+                    {% if wizard.steps.current != "barrier-details-summary" %}
+                        <span class="govuk-caption-l">Section {{ wizard.steps.step1 }} of {{ wizard.steps.count|add:"-1" }}</span>
+                    {% endif %}
                 {% endblock %}
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-two-thirds">

--- a/tests/barriers/test_public_barrier_notes.py
+++ b/tests/barriers/test_public_barrier_notes.py
@@ -11,8 +11,15 @@ class PublicBarrierNotesTestCase(MarketAccessTestCase):
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
     @patch("utils.api.client.PublicBarriersResource.create_note")
-    def test_note_cannot_be_empty(self, mock_create, mock_get_notes, mock_get_activity):
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    def test_note_cannot_be_empty(
+        self, mock_get_user, mock_user, mock_create, mock_get_notes, mock_get_activity
+    ):
+        mock_get_user.return_value = self.general_user
+        mock_user.return_value = self.general_user
         mock_get_notes.return_value = []
+        mock_get_activity.return_value = self.public_barrier_activity
         response = self.client.post(
             reverse(
                 "barriers:public_barrier_detail",
@@ -29,10 +36,20 @@ class PublicBarrierNotesTestCase(MarketAccessTestCase):
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
     @patch("utils.api.client.PublicBarriersResource.create_note")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
     def test_add_note_success(
-        self, mock_create_note, mock_get_notes, mock_get_activity
+        self,
+        mock_get_user,
+        mock_user,
+        mock_create_note,
+        mock_get_notes,
+        mock_get_activity,
     ):
         mock_get_notes.return_value = []
+        mock_get_activity.return_value = self.public_barrier_activity
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
         response = self.client.post(
             reverse(
                 "barriers:public_barrier_detail",
@@ -46,9 +63,19 @@ class PublicBarrierNotesTestCase(MarketAccessTestCase):
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
     @patch("utils.api.client.PublicBarrierNotesResource.patch")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
     def test_edit_note_success(
-        self, mock_patch_note, mock_get_notes, mock_get_activity
+        self,
+        mock_get_user,
+        mock_user,
+        mock_patch_note,
+        mock_get_notes,
+        mock_get_activity,
     ):
+        mock_get_activity.return_value = self.public_barrier_activity
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
         mock_get_notes.return_value = [
             PublicBarrierNote(
                 {
@@ -70,9 +97,19 @@ class PublicBarrierNotesTestCase(MarketAccessTestCase):
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
     @patch("utils.api.client.PublicBarrierNotesResource.delete")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
     def test_delete_note_success(
-        self, mock_delete_note, mock_get_notes, mock_get_activity
+        self,
+        mock_get_user,
+        mock_user,
+        mock_delete_note,
+        mock_get_notes,
+        mock_get_activity,
     ):
+        mock_get_activity.return_value = self.public_barrier_activity
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
         mock_get_notes.return_value = [
             PublicBarrierNote(
                 {

--- a/tests/barriers/test_public_barriers.py
+++ b/tests/barriers/test_public_barriers.py
@@ -1,3 +1,4 @@
+import logging
 from http import HTTPStatus
 
 from django.urls import reverse
@@ -5,13 +6,15 @@ from mock import patch
 
 from core.tests import MarketAccessTestCase
 
+logger = logging.getLogger(__name__)
+
 
 class EditPublicBarrierTitleTestCase(MarketAccessTestCase):
     def test_edit_title_has_initial_data(self):
         response = self.client.get(
             reverse(
                 "barriers:edit_public_barrier_title",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 12},
             )
         )
         assert response.status_code == HTTPStatus.OK
@@ -19,12 +22,12 @@ class EditPublicBarrierTitleTestCase(MarketAccessTestCase):
         form = response.context["form"]
         assert form.initial["title"] == self.public_barrier["title"]
 
-    @patch("utils.api.resources.APIResource.patch")
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
     def test_title_cannot_be_empty(self, mock_patch):
         response = self.client.post(
             reverse(
                 "barriers:edit_public_barrier_title",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 15},
             ),
             data={"title": ""},
         )
@@ -34,21 +37,27 @@ class EditPublicBarrierTitleTestCase(MarketAccessTestCase):
         assert "title" in form.errors
         assert mock_patch.called is False
 
-    @patch("utils.api.resources.APIResource.patch")
-    def test_edit_title_calls_api(self, mock_patch):
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
+    @patch("django.contrib.messages.add_message")
+    def test_edit_title_calls_api(self, mock_add_message, mock_patch):
         mock_patch.return_value = self.barrier
         response = self.client.post(
             reverse(
                 "barriers:edit_public_barrier_title",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 5},
             ),
             data={"title": "New Title"},
         )
         mock_patch.assert_called_with(
             id=self.barrier["id"],
-            title="New Title",
+            form_name="barrier-public-title",
+            values={"title": "New Title"},
         )
         assert response.status_code == HTTPStatus.FOUND
+
+        expected_message_tag = "The public title has been added"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
 
 
 class EditPublicBarrierSummaryTestCase(MarketAccessTestCase):
@@ -56,7 +65,7 @@ class EditPublicBarrierSummaryTestCase(MarketAccessTestCase):
         response = self.client.get(
             reverse(
                 "barriers:edit_public_barrier_summary",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 17},
             )
         )
         assert response.status_code == HTTPStatus.OK
@@ -64,12 +73,12 @@ class EditPublicBarrierSummaryTestCase(MarketAccessTestCase):
         form = response.context["form"]
         assert form.initial["summary"] == self.public_barrier["summary"]
 
-    @patch("utils.api.resources.APIResource.patch")
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
     def test_summary_cannot_be_empty(self, mock_patch):
         response = self.client.post(
             reverse(
                 "barriers:edit_public_barrier_summary",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 20},
             ),
             data={"summary": ""},
         )
@@ -79,21 +88,27 @@ class EditPublicBarrierSummaryTestCase(MarketAccessTestCase):
         assert "summary" in form.errors
         assert mock_patch.called is False
 
-    @patch("utils.api.resources.APIResource.patch")
-    def test_edit_summary_calls_api(self, mock_patch):
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
+    @patch("django.contrib.messages.add_message")
+    def test_edit_summary_calls_api(self, mock_add_message, mock_patch):
         mock_patch.return_value = self.barrier
         response = self.client.post(
             reverse(
                 "barriers:edit_public_barrier_summary",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 24},
             ),
             data={"summary": "New summary"},
         )
         mock_patch.assert_called_with(
             id=self.barrier["id"],
-            summary="New summary",
+            form_name="barrier-public-summary",
+            values={"summary": "New summary"},
         )
         assert response.status_code == HTTPStatus.FOUND
+
+        expected_message_tag = "The public summary has been added"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
 
 
 class EditPublicBarrierEligibilityTestCase(MarketAccessTestCase):
@@ -101,7 +116,7 @@ class EditPublicBarrierEligibilityTestCase(MarketAccessTestCase):
         response = self.client.get(
             reverse(
                 "barriers:edit_public_eligibility",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 27},
             )
         )
         assert response.status_code == HTTPStatus.OK
@@ -122,7 +137,7 @@ class EditPublicBarrierEligibilityTestCase(MarketAccessTestCase):
         response = self.client.post(
             reverse(
                 "barriers:edit_public_eligibility",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 20},
             ),
         )
         assert response.status_code == HTTPStatus.OK
@@ -132,81 +147,289 @@ class EditPublicBarrierEligibilityTestCase(MarketAccessTestCase):
         assert mock_patch.called is False
 
     @patch("utils.api.resources.APIResource.patch")
-    def test_edit_eligibility_calls_api(self, mock_patch):
+    @patch("django.contrib.messages.add_message")
+    def test_edit_eligibility_yes_calls_api(self, mock_add_message, mock_patch):
         mock_patch.return_value = self.barrier
         response = self.client.post(
             reverse(
                 "barriers:edit_public_eligibility",
-                kwargs={"barrier_id": self.barrier["id"]},
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 30},
             ),
-            data={"public_eligibility": "yes", "allowed_summary": "summary"},
+            data={"public_eligibility": "yes", "public_eligibility_summary": ""},
         )
         mock_patch.assert_called_with(
             id=self.barrier["id"],
-            public_eligibility=True,
-            public_eligibility_postponed=False,
+            public_eligibility="yes",
+            public_eligibility_summary="",
+        )
+        assert response.status_code == HTTPStatus.FOUND
+
+        expected_message_tag = "The barrier publication status has been set to: allowed"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.APIResource.patch")
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
+    @patch("django.contrib.messages.add_message")
+    def test_edit_eligibility_no_calls_api(
+        self, mock_add_message, mock_report, mock_patch
+    ):
+        mock_patch.return_value = self.barrier
+        response = self.client.post(
+            reverse(
+                "barriers:edit_public_eligibility",
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 3},
+            ),
+            data={"public_eligibility": "no", "public_eligibility_summary": "summary"},
+        )
+        mock_patch.assert_called_with(
+            id=self.barrier["id"],
+            public_eligibility="no",
             public_eligibility_summary="summary",
         )
-        assert response.status_code == HTTPStatus.FOUND
 
-
-class PublicBarrierActionsTestCase(MarketAccessTestCase):
-    @patch("utils.api.resources.PublicBarriersResource.mark_as_ready")
-    def test_mark_as_ready_calls_api(self, mock_mark_as_ready):
-        response = self.client.post(
-            reverse(
-                "barriers:public_barrier_detail",
-                kwargs={"barrier_id": self.barrier["id"]},
-            ),
-            data={"action": "mark-as-ready"},
+        assert mock_report.call_count == 2
+        mock_report.assert_any_call(
+            id=self.barrier["id"],
+            form_name="barrier-public-title",
+            values={"title": ""},
+        )
+        mock_report.assert_any_call(
+            id=self.barrier["id"],
+            form_name="barrier-public-summary",
+            values={"summary": ""},
         )
         assert response.status_code == HTTPStatus.FOUND
-        assert mock_mark_as_ready.called is True
 
-    @patch("utils.api.resources.PublicBarriersResource.publish")
-    def test_publish_calls_api(self, mock_publish):
+        expected_message_tag = "The publication status is set to: not allowed"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+
+class ApprovePublicBarrierSummaryTestCase(MarketAccessTestCase):
+    @patch("utils.api.resources.PublicBarriersResource.ready_for_publishing")
+    @patch("utils.api.resources.PublicBarriersResource.patch")
+    @patch("django.contrib.messages.add_message")
+    def test_approve_with_summary(self, mock_add_message, mock_patch, mock_ready):
         response = self.client.post(
             reverse(
-                "barriers:public_barrier_detail",
+                "barriers:approve_public_barrier_confirmation",
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 17},
+            ),
+            data={
+                "confirmation": True,
+                "public_approval_summary": "Test summary",
+            },
+        )
+        assert response.status_code == HTTPStatus.FOUND
+        assert mock_ready.called is True
+        assert mock_patch.called is True
+
+        expected_message_tag = (
+            "This barrier has been approved and is now with the GOV.UK content team"
+        )
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.PublicBarriersResource.ready_for_publishing")
+    @patch("utils.api.resources.PublicBarriersResource.patch")
+    @patch("django.contrib.messages.add_message")
+    def test_approve_without_summary(self, mock_add_message, mock_patch, mock_ready):
+        response = self.client.post(
+            reverse(
+                "barriers:approve_public_barrier_confirmation",
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 30},
+            ),
+            data={
+                "confirmation": True,
+                "public_approval_summary": "",
+            },
+        )
+        assert response.status_code == HTTPStatus.FOUND
+        assert mock_ready.called is True
+        assert mock_patch.called is False
+
+        expected_message_tag = (
+            "This barrier has been approved and is now with the GOV.UK content team"
+        )
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.PublicBarriersResource.ready_for_publishing")
+    @patch("utils.api.resources.PublicBarriersResource.patch")
+    def test_approve_failure(self, mock_patch, mock_ready):
+        response = self.client.post(
+            reverse(
+                "barriers:approve_public_barrier_confirmation",
+                kwargs={"barrier_id": self.barrier["id"], "countdown": 18},
+            ),
+            data={"confirmation": False, "public_approval_summary": ""},
+        )
+        assert response.status_code == HTTPStatus.OK
+        form = response.context["form"]
+        assert form.is_valid() is False
+        assert "confirmation" in form.errors
+        assert mock_ready.called is False
+        assert mock_patch.called is False
+
+
+class PublishBarrierConfirmationTestCase(MarketAccessTestCase):
+    @patch("utils.api.resources.PublicBarriersResource.publish")
+    @patch("django.contrib.messages.add_message")
+    def test_publish_confirmation(self, mock_add_message, mock_publish):
+        response = self.client.post(
+            reverse(
+                "barriers:publish_public_barrier_confirmation",
                 kwargs={"barrier_id": self.barrier["id"]},
             ),
-            data={"action": "publish"},
+            data={},
         )
         assert response.status_code == HTTPStatus.FOUND
         assert mock_publish.called is True
 
-    @patch("utils.api.resources.PublicBarriersResource.mark_as_in_progress")
-    def test_mark_as_in_progress_calls_api(self, mock_mark_as_in_progress):
-        response = self.client.post(
-            reverse(
-                "barriers:public_barrier_detail",
-                kwargs={"barrier_id": self.barrier["id"]},
-            ),
-            data={"action": "mark-as-in-progress"},
-        )
-        assert response.status_code == HTTPStatus.FOUND
-        assert mock_mark_as_in_progress.called is True
+        expected_message_tag = "This barrier has been published on GOV.UK"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
 
+
+class UnpublishBarrierConfirmationTestCase(MarketAccessTestCase):
     @patch("utils.api.resources.PublicBarriersResource.unpublish")
-    def test_unpublish_calls_api(self, mock_unpublish):
+    @patch("utils.api.resources.PublicBarriersResource.patch")
+    @patch("django.contrib.messages.add_message")
+    def test_unpublish_confirmation(self, mock_add_message, mock_patch, mock_unpublish):
         response = self.client.post(
             reverse(
-                "barriers:public_barrier_detail",
+                "barriers:unpublish_public_barrier_confirmation",
                 kwargs={"barrier_id": self.barrier["id"]},
             ),
-            data={"action": "unpublish"},
+            data={
+                "public_publisher_summary": "Test summary",
+            },
         )
         assert response.status_code == HTTPStatus.FOUND
         assert mock_unpublish.called is True
+        assert mock_patch.called is True
 
-    @patch("utils.api.resources.PublicBarriersResource.ignore_all_changes")
-    def test_ignore_changes_calls_api(self, mock_ignore_changes):
+        expected_message_tag = "This barrier has been removed from GOV.UK"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.PublicBarriersResource.unpublish")
+    @patch("utils.api.resources.PublicBarriersResource.patch")
+    def test_unpublish_confirmation_missing_summary(self, mock_patch, mock_unpublish):
+        response = self.client.post(
+            reverse(
+                "barriers:unpublish_public_barrier_confirmation",
+                kwargs={"barrier_id": self.barrier["id"]},
+            ),
+            data={
+                "public_publisher_summary": "",
+            },
+        )
+        assert response.status_code == HTTPStatus.OK
+        form = response.context["form"]
+        assert form.is_valid() is False
+        assert "public_publisher_summary" in form.errors
+        assert mock_unpublish.called is False
+        assert mock_patch.called is False
+
+
+class PublicBarrierActionsTestCase(MarketAccessTestCase):
+    @patch("utils.api.resources.PublicBarriersResource.ready_for_approval")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    @patch("utils.api.client.PublicBarriersResource.get_activity")
+    @patch("utils.api.client.PublicBarriersResource.get_notes")
+    @patch("django.contrib.messages.add_message")
+    def test_submit_for_approval_calls_api(
+        self,
+        mock_add_message,
+        mock_get_notes,
+        mock_get_activity,
+        mock_get_user,
+        mock_user,
+        mock_ready_for_approval,
+    ):
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
+        mock_get_notes.return_value = []
+        mock_get_activity.return_value = self.public_barrier_activity
         response = self.client.post(
             reverse(
                 "barriers:public_barrier_detail",
                 kwargs={"barrier_id": self.barrier["id"]},
             ),
-            data={"action": "ignore-changes"},
+            data={"action": "submit-for-approval"},
         )
         assert response.status_code == HTTPStatus.FOUND
-        assert mock_ignore_changes.called is True
+        assert mock_ready_for_approval.called is True
+
+        expected_message_tag = "This barrier is now awaiting approval"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.PublicBarriersResource.allow_for_publishing_process")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    @patch("utils.api.client.PublicBarriersResource.get_activity")
+    @patch("utils.api.client.PublicBarriersResource.get_notes")
+    @patch("django.contrib.messages.add_message")
+    def test_remove_for_approval_calls_api(
+        self,
+        mock_add_message,
+        mock_get_notes,
+        mock_get_activity,
+        mock_get_user,
+        mock_user,
+        mock_allow_for_publishing_process,
+    ):
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
+        mock_get_notes.return_value = []
+        mock_get_activity.return_value = self.public_barrier_activity
+        response = self.client.post(
+            reverse(
+                "barriers:public_barrier_detail",
+                kwargs={"barrier_id": self.barrier["id"]},
+            ),
+            data={"action": "remove-for-approval"},
+        )
+        assert response.status_code == HTTPStatus.FOUND
+        assert mock_allow_for_publishing_process.called is True
+
+        expected_message_tag = "This barrier is not ready for approval"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)
+
+    @patch("utils.api.resources.PublicBarriersResource.ready_for_approval")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    @patch("utils.api.client.PublicBarriersResource.get_activity")
+    @patch("utils.api.client.PublicBarriersResource.get_notes")
+    @patch("django.contrib.messages.add_message")
+    def test_revoke_approval_calls_api(
+        self,
+        mock_add_message,
+        mock_get_notes,
+        mock_get_activity,
+        mock_get_user,
+        mock_user,
+        mock_ready_for_approval,
+    ):
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
+        mock_get_notes.return_value = []
+        mock_get_activity.return_value = self.public_barrier_activity
+        response = self.client.post(
+            reverse(
+                "barriers:public_barrier_detail",
+                kwargs={"barrier_id": self.barrier["id"]},
+            ),
+            data={"action": "remove-for-publishing"},
+        )
+        assert response.status_code == HTTPStatus.FOUND
+        assert mock_ready_for_approval.called is True
+
+        expected_message_tag = "This barrier needs to be approved again"
+        assert mock_add_message.called is True
+        assert expected_message_tag in str(mock_add_message.call_args)

--- a/tests/barriers/test_public_barriers_view.py
+++ b/tests/barriers/test_public_barriers_view.py
@@ -1,3 +1,4 @@
+import logging
 from http import HTTPStatus
 
 from django.urls import resolve, reverse
@@ -5,6 +6,8 @@ from mock import patch
 
 from barriers.views.public_barriers import PublicBarrierDetail
 from core.tests import MarketAccessTestCase
+
+logger = logging.getLogger(__name__)
 
 
 class PublicBarrierViewTestCase(MarketAccessTestCase):
@@ -15,10 +18,15 @@ class PublicBarrierViewTestCase(MarketAccessTestCase):
     @patch("utils.api.client.PublicBarriersResource.get")
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
-    def test_public_barrier_view_loads_correct_template(
-        self, _mock_get_notes, _mock_get_activity, mock_get
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    def test_public_barrier_view_loads_correct_template_general_user(
+        self, mock_get_user, mock_user, mock_get_activity, _mock_get_notes, mock_get
     ):
+        mock_get_user.return_value = self.general_user
+        mock_user.return_value = self.general_user
         mock_get.return_value = self.barrier
+        mock_get_activity.return_value = self.public_barrier_activity
         url = reverse(
             "barriers:public_barrier_detail", kwargs={"barrier_id": self.barrier["id"]}
         )
@@ -27,19 +35,79 @@ class PublicBarrierViewTestCase(MarketAccessTestCase):
 
         assert HTTPStatus.OK == response.status_code
         self.assertTemplateUsed(response, "barriers/public_barriers/detail.html")
+        assert response.context_data["user_role"] == "General user"
+
+        # Test an approved barrier passed the approvers name to context
+        assert response.context_data["approver_name"] == "Test-user"
 
     @patch("utils.api.client.PublicBarriersResource.get")
     @patch("utils.api.client.PublicBarriersResource.get_activity")
     @patch("utils.api.client.PublicBarriersResource.get_notes")
-    def test_public_barrier_view_loads_html(
-        self, _mock_get_notes, _mock_get_activity, mock_get
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    def test_public_barrier_view_loads_correct_template_approver(
+        self, mock_get_user, mock_user, mock_get_activity, _mock_get_notes, mock_get
     ):
+        mock_get_user.return_value = self.approver_user
+        mock_user.return_value = self.approver_user
+        mock_get.return_value = self.barrier
+        mock_get_activity.return_value = self.public_barrier_activity
+        url = reverse(
+            "barriers:public_barrier_detail", kwargs={"barrier_id": self.barrier["id"]}
+        )
+
+        response = self.client.get(url)
+
+        assert HTTPStatus.OK == response.status_code
+        self.assertTemplateUsed(response, "barriers/public_barriers/detail.html")
+        assert response.context_data["user_role"] == "Approver"
+
+    @patch("utils.api.client.PublicBarriersResource.get")
+    @patch("utils.api.client.PublicBarriersResource.get_activity")
+    @patch("utils.api.client.PublicBarriersResource.get_notes")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    def test_public_barrier_view_loads_correct_template_publisher(
+        self, mock_get_user, mock_user, mock_get_activity, _mock_get_notes, mock_get
+    ):
+        mock_get_user.return_value = self.publisher_user
+        mock_user.return_value = self.publisher_user
+        mock_get.return_value = self.barrier
+        mock_get_activity.return_value = self.public_barrier_activity
+        url = reverse(
+            "barriers:public_barrier_detail", kwargs={"barrier_id": self.barrier["id"]}
+        )
+
+        response = self.client.get(url)
+
+        assert HTTPStatus.OK == response.status_code
+        self.assertTemplateUsed(response, "barriers/public_barriers/detail.html")
+        assert response.context_data["user_role"] == "Publisher"
+
+        # Test an published barrier passes the publishers name and date to context
+        assert response.context_data["publisher_name"] == "Test-user"
+        assert (
+            str(response.context_data["published_date"])
+            == "2020-03-19 09:18:16.687291+00:00"
+        )
+
+    @patch("utils.api.client.PublicBarriersResource.get")
+    @patch("utils.api.client.PublicBarriersResource.get_activity")
+    @patch("utils.api.client.PublicBarriersResource.get_notes")
+    @patch("utils.api.resources.UsersResource.get_current")
+    @patch("users.mixins.UserMixin.get_user")
+    def test_public_barrier_view_loads_html(
+        self, mock_get_user, mock_user, mock_get_activity, _mock_get_notes, mock_get
+    ):
+        mock_get_user.return_value = self.general_user
+        mock_user.return_value = self.general_user
         mock_get.return_value = self.public_barrier
+        mock_get_activity.return_value = self.public_barrier_activity
         url = reverse(
             "barriers:public_barrier_detail", kwargs={"barrier_id": self.barrier["id"]}
         )
         title = "<title>Market Access - Public barrier</title>"
-        section_head = '<h2 class="summary-group__heading">Public view:'
+        section_head = '<h2 class="summary-group-public-view__heading">Prepare for publication</h2>'
         notes_head = '<h2 class="section-heading govuk-!-margin-bottom-0">Internal notes and updates</h2>'
         add_note_button = (
             '<a class="govuk-button button--primary" href="?add-note=1">Add a note</a>'

--- a/tests/reports/test_wizard_step_public_steps.py
+++ b/tests/reports/test_wizard_step_public_steps.py
@@ -1,0 +1,207 @@
+import logging
+import random
+import string
+
+from core.tests import MarketAccessTestCase
+from reports.report_barrier_forms import (
+    BarrierPublicEligibilityForm,
+    BarrierPublicInformationGateForm,
+    BarrierPublicSummaryForm,
+    BarrierPublicTitleForm,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ReportWizardPublicEligibilityTestCase(MarketAccessTestCase):
+    # make django-test path=reports/test_wizard_step_public_steps.py::ReportWizardPublicEligibilityTestCase
+
+    def test_valid_form_entry(self):
+        form = BarrierPublicEligibilityForm(
+            {
+                "public_eligibility": "yes",
+                "public_eligibility_summary": "",
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["public_eligibility"] is True
+        assert form.cleaned_data["public_eligibility_summary"] == ""
+
+    def test_valid_form_entry_negative_path(self):
+        test_summary = (
+            "This is the summary to say why the barrier is not eligible for the public"
+        )
+        form = BarrierPublicEligibilityForm(
+            {
+                "public_eligibility": "no",
+                "public_eligibility_summary": test_summary,
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["public_eligibility"] is False
+        assert test_summary in form.cleaned_data["public_eligibility_summary"]
+
+    def test_invalid_form_missing_summary(self):
+        form = BarrierPublicEligibilityForm(
+            {
+                "public_eligibility": "no",
+                "public_eligibility_summary": "",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Enter a reason for not publishing this barrier"
+        assert expected_error_message in str(form.errors["public_eligibility_summary"])
+
+    def test_empty_form(self):
+        form = BarrierPublicEligibilityForm(
+            {
+                "public_eligibility": "",
+                "public_eligibility_summary": "",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = (
+            "Select whether this barrier should be published on GOV.UK, once approved"
+        )
+        assert expected_error_message in str(form.errors["public_eligibility"])
+
+    def test_valid_form_entry_clears_summary(self):
+        test_summary = (
+            "This is the summary to say why the barrier is not eligible for the public"
+        )
+        form = BarrierPublicEligibilityForm(
+            {
+                "public_eligibility": "yes",
+                "public_eligibility_summary": test_summary,
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["public_eligibility"] is True
+        assert form.cleaned_data["public_eligibility_summary"] == ""
+
+
+class ReportWizardPublicInformationGateTestCase(MarketAccessTestCase):
+    # make django-test path=reports/test_wizard_step_public_steps.py::ReportWizardPublicInformationGateTestCase
+
+    def test_valid_form_entry(self):
+        form = BarrierPublicInformationGateForm(
+            {
+                "public_information": "true",
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["public_information"] == "true"
+
+    def test_valid_form_entry_negative_path(self):
+        form = BarrierPublicInformationGateForm(
+            {
+                "public_information": "false",
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["public_information"] == "false"
+
+    def test_invalid_form_entry(self):
+        form = BarrierPublicInformationGateForm(
+            {
+                "public_information": "Yea",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Select a valid choice"
+        assert expected_error_message in str(form.errors["public_information"])
+
+    def test_empty_form_entry(self):
+        form = BarrierPublicInformationGateForm(
+            {
+                "public_information": "",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = (
+            "Select whether you want to publish the barrier now or later"
+        )
+        assert expected_error_message in str(form.errors["public_information"])
+
+
+class ReportWizardPublicTitleTestCase(MarketAccessTestCase):
+    # make django-test path=reports/test_wizard_step_public_steps.py::ReportWizardPublicTitleTestCase
+
+    def test_valid_form_entry(self):
+        form = BarrierPublicTitleForm(
+            {
+                "title": "Public Title Example",
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["title"] == "Public Title Example"
+
+    def test_invalid_form_empty(self):
+        form = BarrierPublicTitleForm(
+            {
+                "title": "",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Enter a public title for this barrier"
+        assert expected_error_message in str(form.errors["title"])
+
+    def test_invalid_form_too_long(self):
+        test_title = "".join(random.choices(string.ascii_letters, k=300))
+        form = BarrierPublicTitleForm(
+            {
+                "title": test_title,
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Title should be 255 characters or less"
+        assert expected_error_message in str(form.errors["title"])
+
+
+class ReportWizardPublicSummaryTestCase(MarketAccessTestCase):
+    # make django-test path=reports/test_wizard_step_public_steps.py::ReportWizardPublicSummaryTestCase
+
+    def test_valid_form_entry(self):
+        form = BarrierPublicSummaryForm(
+            {
+                "summary": "Public summary example",
+            }
+        )
+
+        assert form.is_valid()
+        assert form.cleaned_data["summary"] == "Public summary example"
+
+    def test_invalid_form_empty(self):
+        form = BarrierPublicSummaryForm(
+            {
+                "summary": "",
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Enter a public summary for this barrier"
+        assert expected_error_message in str(form.errors["summary"])
+
+    def test_invalid_form_too_long(self):
+        test_summary = "".join(random.choices(string.ascii_letters, k=2001))
+        form = BarrierPublicSummaryForm(
+            {
+                "summary": test_summary,
+            }
+        )
+
+        assert form.is_valid() is False
+        expected_error_message = "Summary should be 1500 characters or less"
+        assert expected_error_message in str(form.errors["summary"])

--- a/tests/reports/test_wizard_step_status.py
+++ b/tests/reports/test_wizard_step_status.py
@@ -361,7 +361,7 @@ class ReportWizardStatusStepTestCase(MarketAccessTestCase):
         )
 
         assert form.is_valid() is False
-        expected_error_message = "Enter a date or select 'I don't know'."
+        expected_error_message = "Enter the date the barrier started affecting trade or select ‘I do not know’"
         assert expected_error_message in form.errors["start_date"]
 
     def test_error_start_date_and_dont_know_both_entered(self):
@@ -380,7 +380,7 @@ class ReportWizardStatusStepTestCase(MarketAccessTestCase):
         )
 
         assert form.is_valid() is False
-        expected_error_message = "Enter a date or select 'I don't know'."
+        expected_error_message = "Enter the date the barrier started affecting trade or select ‘I do not know’"
         assert expected_error_message in form.errors["start_date"]
 
     def test_error_dont_know_currently_active_missing(self):

--- a/tests/reports/test_wizard_step_summary_and_submit.py
+++ b/tests/reports/test_wizard_step_summary_and_submit.py
@@ -12,6 +12,10 @@ from reports.report_barrier_forms import (
     BarrierDetailsSummaryForm,
     BarrierExportTypeForm,
     BarrierLocationForm,
+    BarrierPublicEligibilityForm,
+    BarrierPublicInformationGateForm,
+    BarrierPublicSummaryForm,
+    BarrierPublicTitleForm,
     BarrierSectorsAffectedForm,
     BarrierStatusForm,
     BarrierTradeDirectionForm,
@@ -27,17 +31,10 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
     # Test suite for loading the summary step of the form
     # make django-test path=reports/test_wizard_step_summary_and_submit.py::SummaryPageLoadTestCase
 
-    @patch("utils.api.resources.ReportsResource.get")
-    @patch(
-        "reports.report_barrier_view.ReportBarrierWizardView.get_cleaned_data_for_step"
-    )
-    @patch("utils.api.resources.CommoditiesResource.list")
-    def test_load_summary_page(
-        self, commodity_api_call_patch, report_get_cleaned_data_patch, report_get_patch
-    ):
+    def setUp(self):
         # Create mock session data - use named tuple method to create object, not dict
-        session_mock = namedtuple("session_mock", "prefix data extra_data")
-        session_data = session_mock(
+        self.session_mock = namedtuple("session_mock", "prefix data extra_data")
+        self.session_data = self.session_mock(
             prefix="wizard_report_barrier_wizard_view",
             extra_data={},
             data={
@@ -50,14 +47,18 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
                     "barrier-sectors-affected": {},
                     "barrier-companies-affected": {},
                     "barrier-export-type": {},
+                    "barrier-public-eligibility": {},
+                    "barrier-public-information-gate": {},
+                    "barrier-public-title": {},
+                    "barrier-public-summary": {},
                 },
                 "meta": {"barrier_id": "b9bc718d-f535-413a-a2c0-8868351b44f2"},
             },
         )
 
         # Create mock steps data - use named tuple method to create object, not dict
-        steps_mock = namedtuple("steps_mock", "steps current")
-        steps_data = steps_mock(
+        self.steps_mock = namedtuple("steps_mock", "steps current")
+        self.steps_data = self.steps_mock(
             steps={
                 "barrier-about",
                 "barrier-status",
@@ -66,13 +67,17 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
                 "barrier-sectors-affected",
                 "barrier-companies-affected",
                 "barrier-export-type",
+                "barrier-public-eligibility",
+                "barrier-public-information-gate",
+                "barrier-public-title",
+                "barrier-public-summary",
                 "barrier-details-summary",
             },
             current="barrier-details-summary",
         )
 
         # Create mock commodity response object
-        commodity_mock_object = BarrierCommodity(
+        self.commodity_mock_object = BarrierCommodity(
             {
                 "commodity": "A Thing",
                 "code": "1002000000",
@@ -80,8 +85,8 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
             }
         )
 
-        about_cleaned_data = {"title": "vvvcvcvvbc", "summary": "cbcbcvbcbvc"}
-        status_cleaned_data = {
+        self.about_cleaned_data = {"title": "vvvcvcvvbc", "summary": "cbcbcvbcbvc"}
+        self.status_cleaned_data = {
             "status": "2",
             "partially_resolved_date": None,
             "partially_resolved_description": "",
@@ -95,7 +100,7 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
             "start_date_known": False,
             "is_currently_active": "NO",
         }
-        location_cleaned_data = {
+        self.location_cleaned_data = {
             "location_select": "TB00016",
             "affect_whole_country": True,
             "admin_areas": [],
@@ -108,8 +113,8 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
             "caused_by_trading_bloc": False,
             "caused_by_admin_areas": False,
         }
-        trade_direction_cleaned_data = {"trade_direction": "1"}
-        sector_cleaned_data = {
+        self.trade_direction_cleaned_data = {"trade_direction": "1"}
+        self.sector_cleaned_data = {
             "main_sector": "af959812-6095-e211-a939-e4115bead28a",
             "sectors": [
                 "9738cecc-5f95-e211-a939-e4115bead28a",
@@ -117,7 +122,7 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
             ],
             "sectors_affected": True,
         }
-        companies_cleaned_data = {
+        self.companies_cleaned_data = {
             "companies_affected": (
                 "[{"
                 '"company_number":"10590916",'
@@ -140,7 +145,7 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
             "companies": [{"id": "10590916", "name": "BLAH LTD"}],
             "related_organisations": [{"id": "", "name": "Fake Company"}],
         }
-        export_types_cleaned_data = {
+        self.export_types_cleaned_data = {
             "export_types": ["goods"],
             "export_description": "An export description",
             "code": "",
@@ -156,28 +161,56 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
                 }
             ],
         }
+        self.public_eligibility_cleaned_data = {
+            "public_eligibility": True,
+            "public_eligibility_summary": "",
+        }
+        self.public_information_gate_cleaned_data = {
+            "public_information": True,
+        }
+        self.public_title_cleaned_data = {
+            "title": "The public title",
+        }
+        self.public_summary_cleaned_data = {
+            "summary": "The public summary",
+        }
+
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch(
+        "reports.report_barrier_view.ReportBarrierWizardView.get_cleaned_data_for_step"
+    )
+    @patch("utils.api.resources.CommoditiesResource.list")
+    def test_load_summary_page_full_report(
+        self, commodity_api_call_patch, report_get_cleaned_data_patch, report_get_patch
+    ):
 
         # Mock the return of get_cleaned_data method but return different
         # dictionary depending on the passed step name.
         report_get_cleaned_data_patch.side_effect = lambda *step_cleaned_data: {
-            ("barrier-about",): about_cleaned_data,
-            ("barrier-status",): status_cleaned_data,
-            ("barrier-location",): location_cleaned_data,
-            ("barrier-trade-direction",): trade_direction_cleaned_data,
-            ("barrier-sectors-affected",): sector_cleaned_data,
-            ("barrier-companies-affected",): companies_cleaned_data,
-            ("barrier-export-type",): export_types_cleaned_data,
+            ("barrier-about",): self.about_cleaned_data,
+            ("barrier-status",): self.status_cleaned_data,
+            ("barrier-location",): self.location_cleaned_data,
+            ("barrier-trade-direction",): self.trade_direction_cleaned_data,
+            ("barrier-sectors-affected",): self.sector_cleaned_data,
+            ("barrier-companies-affected",): self.companies_cleaned_data,
+            ("barrier-export-type",): self.export_types_cleaned_data,
+            ("barrier-public-eligibility",): self.public_eligibility_cleaned_data,
+            (
+                "barrier-public-information-gate",
+            ): self.public_information_gate_cleaned_data,
+            ("barrier-public-title",): self.public_title_cleaned_data,
+            ("barrier-public-summary",): self.public_summary_cleaned_data,
         }[step_cleaned_data]
 
         # Initialise view for test
         view = ReportBarrierWizardView()
-        view.storage = session_data
-        view.steps = steps_data
+        view.storage = self.session_data
+        view.steps = self.steps_data
         view.prefix = ("wizard_report_barrier_wizard_view",)
         view.client = MarketAccessAPIClient()
 
         # Set mock return values
-        commodity_api_call_patch.return_value = [commodity_mock_object]
+        commodity_api_call_patch.return_value = [self.commodity_mock_object]
         report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
         summary_form = BarrierDetailsSummaryForm()
 
@@ -195,45 +228,207 @@ class SummaryPageLoadTestCase(MarketAccessTestCase):
         assert result["companies"] == ["BLAH LTD"]
         assert result["related_organisations"] == ["Fake Company"]
         assert result["codes"] == [{"code": "1002000000", "description": "A Thing"}]
+        assert result["public_eligibility"] == "Can be published, once approved"
+        assert result["public_title"] == "The public title"
+        assert result["public_summary"] == "The public summary"
+
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch(
+        "reports.report_barrier_view.ReportBarrierWizardView.get_cleaned_data_for_step"
+    )
+    @patch("utils.api.resources.CommoditiesResource.list")
+    def test_load_summary_page_ineligible_for_public(
+        self, commodity_api_call_patch, report_get_cleaned_data_patch, report_get_patch
+    ):
+
+        self.public_eligibility_cleaned_data = {
+            "public_eligibility": False,
+            "public_eligibility_summary": "This barrier is not public",
+        }
+
+        self.session_mock = namedtuple("session_mock", "prefix data extra_data")
+        self.session_data = self.session_mock(
+            prefix="wizard_report_barrier_wizard_view",
+            extra_data={},
+            data={
+                "step": "barrier-details-summary",
+                "step_data": {
+                    "barrier-about": {},
+                    "barrier-status": {},
+                    "barrier-location": {},
+                    "barrier-trade-direction": {},
+                    "barrier-sectors-affected": {},
+                    "barrier-companies-affected": {},
+                    "barrier-export-type": {},
+                    "barrier-public-eligibility": {},
+                },
+                "meta": {"barrier_id": "b9bc718d-f535-413a-a2c0-8868351b44f2"},
+            },
+        )
+
+        # Mock the return of get_cleaned_data method but return different
+        # dictionary depending on the passed step name.
+        report_get_cleaned_data_patch.side_effect = lambda *step_cleaned_data: {
+            ("barrier-about",): self.about_cleaned_data,
+            ("barrier-status",): self.status_cleaned_data,
+            ("barrier-location",): self.location_cleaned_data,
+            ("barrier-trade-direction",): self.trade_direction_cleaned_data,
+            ("barrier-sectors-affected",): self.sector_cleaned_data,
+            ("barrier-companies-affected",): self.companies_cleaned_data,
+            ("barrier-export-type",): self.export_types_cleaned_data,
+            ("barrier-public-eligibility",): self.public_eligibility_cleaned_data,
+        }[step_cleaned_data]
+
+        # Initialise view for test
+        view = ReportBarrierWizardView()
+        view.storage = self.session_data
+        view.steps = self.steps_data
+        view.prefix = ("wizard_report_barrier_wizard_view",)
+        view.client = MarketAccessAPIClient()
+
+        # Set mock return values
+        commodity_api_call_patch.return_value = [self.commodity_mock_object]
+        report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
+        summary_form = BarrierDetailsSummaryForm()
+
+        result = view.get_context_data(summary_form)
+
+        # Assert the transformations of stored data to readble values for the summary table
+        # have taken place and have been passed to the form in context.
+        assert result["status"] == "Open"
+        assert result["barrier_location"] == "European Union"
+        assert (
+            result["trade_direction"] == "Exporting from the UK or investing overseas"
+        )
+        assert result["main_sector"] == "Advanced Engineering"
+        assert result["sectors"] == ["Airports", "Automotive"]
+        assert result["companies"] == ["BLAH LTD"]
+        assert result["related_organisations"] == ["Fake Company"]
+        assert result["codes"] == [{"code": "1002000000", "description": "A Thing"}]
+        assert result["public_eligibility"] == "Cannot be published"
+        assert "public_title" not in result.keys()
+        assert "public_summary" not in result.keys()
+
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch(
+        "reports.report_barrier_view.ReportBarrierWizardView.get_cleaned_data_for_step"
+    )
+    @patch("utils.api.resources.CommoditiesResource.list")
+    def test_load_summary_page_eligible_for_public_later(
+        self, commodity_api_call_patch, report_get_cleaned_data_patch, report_get_patch
+    ):
+
+        self.public_information_gate_cleaned_data = {
+            "public_information": False,
+        }
+
+        self.session_mock = namedtuple("session_mock", "prefix data extra_data")
+        self.session_data = self.session_mock(
+            prefix="wizard_report_barrier_wizard_view",
+            extra_data={},
+            data={
+                "step": "barrier-details-summary",
+                "step_data": {
+                    "barrier-about": {},
+                    "barrier-status": {},
+                    "barrier-location": {},
+                    "barrier-trade-direction": {},
+                    "barrier-sectors-affected": {},
+                    "barrier-companies-affected": {},
+                    "barrier-export-type": {},
+                    "barrier-public-eligibility": {},
+                    "barrier-public-information-gate": {},
+                },
+                "meta": {"barrier_id": "b9bc718d-f535-413a-a2c0-8868351b44f2"},
+            },
+        )
+
+        # Mock the return of get_cleaned_data method but return different
+        # dictionary depending on the passed step name.
+        report_get_cleaned_data_patch.side_effect = lambda *step_cleaned_data: {
+            ("barrier-about",): self.about_cleaned_data,
+            ("barrier-status",): self.status_cleaned_data,
+            ("barrier-location",): self.location_cleaned_data,
+            ("barrier-trade-direction",): self.trade_direction_cleaned_data,
+            ("barrier-sectors-affected",): self.sector_cleaned_data,
+            ("barrier-companies-affected",): self.companies_cleaned_data,
+            ("barrier-export-type",): self.export_types_cleaned_data,
+            ("barrier-public-eligibility",): self.public_eligibility_cleaned_data,
+            (
+                "barrier-public-information-gate",
+            ): self.public_information_gate_cleaned_data,
+        }[step_cleaned_data]
+
+        # Initialise view for test
+        view = ReportBarrierWizardView()
+        view.storage = self.session_data
+        view.steps = self.steps_data
+        view.prefix = ("wizard_report_barrier_wizard_view",)
+        view.client = MarketAccessAPIClient()
+
+        # Set mock return values
+        commodity_api_call_patch.return_value = [self.commodity_mock_object]
+        report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
+        summary_form = BarrierDetailsSummaryForm()
+
+        result = view.get_context_data(summary_form)
+
+        # Assert the transformations of stored data to readble values for the summary table
+        # have taken place and have been passed to the form in context.
+        assert result["status"] == "Open"
+        assert result["barrier_location"] == "European Union"
+        assert (
+            result["trade_direction"] == "Exporting from the UK or investing overseas"
+        )
+        assert result["main_sector"] == "Advanced Engineering"
+        assert result["sectors"] == ["Airports", "Automotive"]
+        assert result["companies"] == ["BLAH LTD"]
+        assert result["related_organisations"] == ["Fake Company"]
+        assert result["codes"] == [{"code": "1002000000", "description": "A Thing"}]
+        assert result["public_eligibility"] == "Can be published, once approved"
+        assert "public_title" not in result.keys()
+        assert "public_summary" not in result.keys()
 
 
 class SubmitReportTestCase(MarketAccessTestCase):
     # Test suite for starting new barriers
     # make django-test path=reports/test_wizard_step_summary_and_submit.py::SubmitReportTestCase
 
-    @patch("utils.api.resources.ReportsResource.get")
-    @patch("utils.api.client.MarketAccessAPIClient.patch")
-    @patch("utils.api.resources.ReportsResource.submit")
-    def test_submit_full_report(
-        self, report_submit_patch, report_update_patch, report_get_patch
-    ):
-
+    def setUp(self):
         # Initialise forms
-        about_form = BarrierAboutForm()
-        status_form = BarrierStatusForm()
-        location_form = BarrierLocationForm()
-        trade_direction_form = BarrierTradeDirectionForm()
-        sectors_form = BarrierSectorsAffectedForm()
-        companies_form = BarrierCompaniesAffectedForm()
-        export_type_form = BarrierExportTypeForm()
-        summary_form = BarrierDetailsSummaryForm()
+        self.about_form = BarrierAboutForm()
+        self.status_form = BarrierStatusForm()
+        self.location_form = BarrierLocationForm()
+        self.trade_direction_form = BarrierTradeDirectionForm()
+        self.sectors_form = BarrierSectorsAffectedForm()
+        self.companies_form = BarrierCompaniesAffectedForm()
+        self.export_type_form = BarrierExportTypeForm()
+        self.public_eligibility_form = BarrierPublicEligibilityForm()
+        self.public_information_gate_form = BarrierPublicInformationGateForm()
+        self.public_title_form = BarrierPublicTitleForm()
+        self.public_summary_form = BarrierPublicSummaryForm()
+        self.summary_form = BarrierDetailsSummaryForm()
 
         # Set form prefixes for done to identify form correctly
-        about_form.prefix = "barrier-about"
-        status_form.prefix = "barrier-status"
-        location_form.prefix = "barrier-location"
-        trade_direction_form.prefix = "barrier-trade-direction"
-        sectors_form.prefix = "barrier-sectors-affected"
-        companies_form.prefix = "barrier-companies-affected"
-        export_type_form.prefix = "barrier-export-type"
-        summary_form.prefix = "barrier-details-summary"
+        self.about_form.prefix = "barrier-about"
+        self.status_form.prefix = "barrier-status"
+        self.location_form.prefix = "barrier-location"
+        self.trade_direction_form.prefix = "barrier-trade-direction"
+        self.sectors_form.prefix = "barrier-sectors-affected"
+        self.companies_form.prefix = "barrier-companies-affected"
+        self.export_type_form.prefix = "barrier-export-type"
+        self.public_eligibility_form.prefix = "barrier-public-eligibility"
+        self.public_information_gate_form.prefix = "barrier-public-information-gate"
+        self.public_title_form.prefix = "barrier-public-title"
+        self.public_summary_form.prefix = "barrier-public-summary"
+        self.summary_form.prefix = "barrier-details-summary"
 
         # Set expected cleaned data
-        about_form.cleaned_data = {
+        self.about_form.cleaned_data = {
             "title": "Fake barrier name",
             "summary": "Fake barrier summary",
         }
-        status_form.cleaned_data = {
+        self.status_form.cleaned_data = {
             "status": "2",
             "partially_resolved_date": None,
             "partially_resolved_description": "",
@@ -247,7 +442,7 @@ class SubmitReportTestCase(MarketAccessTestCase):
             "start_date_known": False,
             "is_currently_active": "YES",
         }
-        location_form.cleaned_data = {
+        self.location_form.cleaned_data = {
             "location_select": "985f66a0-5d95-e211-a939-e4115bead28a",
             "affect_whole_country": True,
             "admin_areas": [],
@@ -260,13 +455,13 @@ class SubmitReportTestCase(MarketAccessTestCase):
             "caused_by_trading_bloc": False,
             "caused_by_admin_areas": False,
         }
-        trade_direction_form.cleaned_data = {"trade_direction": "1"}
-        sectors_form.cleaned_data = {
+        self.trade_direction_form.cleaned_data = {"trade_direction": "1"}
+        self.sectors_form.cleaned_data = {
             "main_sector": "9638cecc-5f95-e211-a939-e4115bead28a",
             "sectors": [],
             "sectors_affected": True,
         }
-        companies_form.cleaned_data = {
+        self.companies_form.cleaned_data = {
             "companies_affected": (
                 "[{"
                 '"company_status":"active",'
@@ -280,7 +475,7 @@ class SubmitReportTestCase(MarketAccessTestCase):
             "companies": [{"id": "10590916", "name": "BLAH LTD"}],
             "related_organisations": [],
         }
-        export_type_form.cleaned_data = {
+        self.export_type_form.cleaned_data = {
             "export_types": ["goods", "services"],
             "export_description": "A description of the export.",
             "code": "",
@@ -296,32 +491,64 @@ class SubmitReportTestCase(MarketAccessTestCase):
                 }
             ],
         }
-        summary_form.cleaned_data = {"details_confirmation": "completed"}
+        self.public_eligibility_form.cleaned_data = {
+            "public_eligibility": True,
+            "public_eligibility_summary": "",
+        }
+        self.public_information_gate_form.cleaned_data = {
+            "public_information": True,
+        }
+        self.public_title_form.cleaned_data = {
+            "title": "The public title",
+        }
+        self.public_summary_form.cleaned_data = {
+            "summary": "The public summary",
+        }
+        self.summary_form.cleaned_data = {"details_confirmation": "completed"}
 
         # Build form list for done method arg
-        form_list = [
-            about_form,
-            status_form,
-            location_form,
-            trade_direction_form,
-            sectors_form,
-            companies_form,
-            export_type_form,
-            summary_form,
+        self.form_list = [
+            self.about_form,
+            self.status_form,
+            self.location_form,
+            self.trade_direction_form,
+            self.sectors_form,
+            self.companies_form,
+            self.export_type_form,
+            self.public_eligibility_form,
+            self.public_information_gate_form,
+            self.public_title_form,
+            self.public_summary_form,
+            self.summary_form,
         ]
 
         # Build form dictionary for done method arg
-        form_dict = [
-            ("barrier-about", about_form),
-            ("barrier-status", status_form),
-            ("barrier-location", location_form),
-            ("barrier-trade-direction", trade_direction_form),
-            ("barrier-sectors-affected", sectors_form),
-            ("barrier-companies-affected", companies_form),
-            ("barrier-export-type", export_type_form),
-            ("barrier-details-summary", summary_form),
+        self.form_dict = [
+            ("barrier-about", self.about_form),
+            ("barrier-status", self.status_form),
+            ("barrier-location", self.location_form),
+            ("barrier-trade-direction", self.trade_direction_form),
+            ("barrier-sectors-affected", self.sectors_form),
+            ("barrier-companies-affected", self.companies_form),
+            ("barrier-export-type", self.export_type_form),
+            ("barrier-public-eligibility", self.public_eligibility_form),
+            ("barrier-public-information-gate", self.public_information_gate_form),
+            ("barrier-public-title", self.public_title_form),
+            ("barrier-public-summary", self.public_summary_form),
+            ("barrier-details-summary", self.summary_form),
         ]
 
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch("utils.api.client.MarketAccessAPIClient.patch")
+    @patch("utils.api.resources.ReportsResource.submit")
+    @patch("utils.api.resources.PublicBarriersResource.report_public_barrier_field")
+    def test_submit_full_report(
+        self,
+        public_barrier_patch,
+        report_submit_patch,
+        report_update_patch,
+        report_get_patch,
+    ):
         # Create mock session data
         session_mock = namedtuple("session_mock", "prefix data")
         session_data = session_mock(
@@ -337,14 +564,14 @@ class SubmitReportTestCase(MarketAccessTestCase):
         # Set mock return values
         report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
 
-        result = view.done(form_list, form_dict)
+        result = view.done(self.form_list, self.form_dict)
 
         # Assert page redirected to the barrier information page
         assert result.status_code == 302
         assert result.url == f"/barriers/{self.draft_barrier['id']}/complete/"
 
         # Assert the report patch mock was called for each form page
-        assert report_update_patch.call_count == 7
+        assert report_update_patch.call_count == 8
 
         # Assert the correct fields from cleaned_data have been included in a patch call
         patch_call_list = report_update_patch.call_args_list
@@ -391,6 +618,217 @@ class SubmitReportTestCase(MarketAccessTestCase):
             "'commodities': [{'code': '1001000000', "
             "'country': '80756b9a-5d95-e211-a939-e4115bead28a', 'trading_bloc': ''}]"
         ) in str(patch_call_list[6])
+        assert (
+            "'public_eligibility': True, " "'public_eligibility_summary': ''"
+        ) in str(patch_call_list[7])
 
         # Assert the report submit mock was called a single time
         report_submit_patch.assert_called_once()
+
+        public_patch_call_list = public_barrier_patch.call_args_list
+        assert "'title': 'The public title'" in str(public_patch_call_list[0])
+        assert "'summary': 'The public summary'" in str(public_patch_call_list[1])
+
+        # Assert the public barrier was marked as in-progress a single time
+        public_barrier_patch.call_count == 2
+
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch("utils.api.client.MarketAccessAPIClient.patch")
+    @patch("utils.api.resources.ReportsResource.submit")
+    @patch("utils.api.resources.PublicBarriersResource.mark_as_in_progress")
+    def test_submit_report_ineligible_for_public(
+        self,
+        public_barrier_patch,
+        report_submit_patch,
+        report_update_patch,
+        report_get_patch,
+    ):
+        # Remove existing forms from lists/dicts
+        self.form_list.pop(10)  # public_summary_form
+        self.form_list.pop(9)  # public_title_form
+        self.form_list.pop(8)  # public_information_gate_form
+
+        # Override setup cleaned_data & forms
+        self.public_eligibility_form.cleaned_data = {
+            "public_eligibility": False,
+            "public_eligibility_summary": "This barrier is not public",
+        }
+
+        # Create mock session data
+        session_mock = namedtuple("session_mock", "prefix data")
+        session_data = session_mock(
+            prefix="wizard_report_barrier_wizard_view",
+            data={"meta": {"barrier_id": "barrier-id-goes-here"}},
+        )
+
+        # Initialise view for test
+        view = ReportBarrierWizardView()
+        view.storage = session_data
+        view.client = MarketAccessAPIClient()
+
+        # Set mock return values
+        report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
+
+        result = view.done(self.form_list, self.form_dict)
+
+        # Assert page redirected to the barrier information page
+        assert result.status_code == 302
+        assert result.url == f"/barriers/{self.draft_barrier['id']}/complete/"
+
+        # Assert the report patch mock was called for each form page
+        assert report_update_patch.call_count == 8
+
+        # Assert the correct fields from cleaned_data have been included in a patch call
+        patch_call_list = report_update_patch.call_args_list
+        # About fields
+        assert "'title': 'Fake barrier name'" in str(patch_call_list[0])
+        assert "'summary': 'Fake barrier summary'" in str(patch_call_list[0])
+        # Status fields
+        assert "'status': '2'" in str(patch_call_list[1])
+        assert "'start_date': None" in str(patch_call_list[1])
+        assert "'currently_active': 'YES'" in str(patch_call_list[1])
+        assert "'status_date': '2023-07-24'" in str(patch_call_list[1])
+        assert "'status_summary': ''" in str(patch_call_list[1])
+        assert "'start_date_known': False" in str(patch_call_list[1])
+        assert "'is_currently_active': 'YES'" in str(patch_call_list[1])
+        # Location fields
+        assert "'affect_whole_country': True" in str(patch_call_list[2])
+        assert "'admin_areas': []" in str(patch_call_list[2])
+        assert "'country': '985f66a0-5d95-e211-a939-e4115bead28a'" in str(
+            patch_call_list[2]
+        )
+        assert "'trading_bloc': ''" in str(patch_call_list[2])
+        assert "'caused_by_trading_bloc': False" in str(patch_call_list[2])
+        assert "'caused_by_admin_areas': False" in str(patch_call_list[2])
+        # Trade direction fields
+        assert "'trade_direction': '1'" in str(patch_call_list[3])
+        # Sector fields
+        assert "'main_sector': '9638cecc-5f95-e211-a939-e4115bead28a'" in str(
+            patch_call_list[4]
+        )
+        assert "'sectors': []" in str(patch_call_list[4])
+        assert "'sectors_affected': True" in str(patch_call_list[4])
+        # Companies fields
+        assert "'companies': [{'id': '10590916', 'name': 'BLAH LTD'}]" in str(
+            patch_call_list[5]
+        )
+        assert "'related_organisations': []" in str(patch_call_list[5])
+        # Export types fields
+        patch_call_list[6]
+        assert "'export_types': ['goods', 'services']" in str(patch_call_list[6])
+        assert "'export_description': 'A description of the export.'" in str(
+            patch_call_list[6]
+        )
+        assert (
+            "'commodities': [{'code': '1001000000', "
+            "'country': '80756b9a-5d95-e211-a939-e4115bead28a', 'trading_bloc': ''}]"
+        ) in str(patch_call_list[6])
+        assert (
+            "'public_eligibility': False, "
+            "'public_eligibility_summary': 'This barrier is not public'"
+        ) in str(patch_call_list[7])
+
+        # Assert the report submit mock was called a single time
+        report_submit_patch.assert_called_once()
+
+        # Assert the public barrier was marked as in-progress a single time
+        public_barrier_patch.call_count == 0
+
+    @patch("utils.api.resources.ReportsResource.get")
+    @patch("utils.api.client.MarketAccessAPIClient.patch")
+    @patch("utils.api.resources.ReportsResource.submit")
+    @patch("utils.api.resources.PublicBarriersResource.mark_as_in_progress")
+    def test_submit_report_eligible_for_public_later(
+        self,
+        public_barrier_patch,
+        report_submit_patch,
+        report_update_patch,
+        report_get_patch,
+    ):
+        # Remove existing forms from lists/dicts
+        self.form_list.pop(10)  # public_summary_form
+        self.form_list.pop(9)  # public_title_form
+
+        # Override setup cleaned_data & forms
+        self.public_information_gate_form.cleaned_data = {
+            "public_information": False,
+        }
+
+        # Create mock session data
+        session_mock = namedtuple("session_mock", "prefix data")
+        session_data = session_mock(
+            prefix="wizard_report_barrier_wizard_view",
+            data={"meta": {"barrier_id": "barrier-id-goes-here"}},
+        )
+
+        # Initialise view for test
+        view = ReportBarrierWizardView()
+        view.storage = session_data
+        view.client = MarketAccessAPIClient()
+
+        # Set mock return values
+        report_get_patch.return_value = ReportsResource.model(self.draft_barrier)
+
+        result = view.done(self.form_list, self.form_dict)
+
+        # Assert page redirected to the barrier information page
+        assert result.status_code == 302
+        assert result.url == f"/barriers/{self.draft_barrier['id']}/complete/"
+
+        # Assert the report patch mock was called for each form page
+        assert report_update_patch.call_count == 8
+
+        # Assert the correct fields from cleaned_data have been included in a patch call
+        patch_call_list = report_update_patch.call_args_list
+        # About fields
+        assert "'title': 'Fake barrier name'" in str(patch_call_list[0])
+        assert "'summary': 'Fake barrier summary'" in str(patch_call_list[0])
+        # Status fields
+        assert "'status': '2'" in str(patch_call_list[1])
+        assert "'start_date': None" in str(patch_call_list[1])
+        assert "'currently_active': 'YES'" in str(patch_call_list[1])
+        assert "'status_date': '2023-07-24'" in str(patch_call_list[1])
+        assert "'status_summary': ''" in str(patch_call_list[1])
+        assert "'start_date_known': False" in str(patch_call_list[1])
+        assert "'is_currently_active': 'YES'" in str(patch_call_list[1])
+        # Location fields
+        assert "'affect_whole_country': True" in str(patch_call_list[2])
+        assert "'admin_areas': []" in str(patch_call_list[2])
+        assert "'country': '985f66a0-5d95-e211-a939-e4115bead28a'" in str(
+            patch_call_list[2]
+        )
+        assert "'trading_bloc': ''" in str(patch_call_list[2])
+        assert "'caused_by_trading_bloc': False" in str(patch_call_list[2])
+        assert "'caused_by_admin_areas': False" in str(patch_call_list[2])
+        # Trade direction fields
+        assert "'trade_direction': '1'" in str(patch_call_list[3])
+        # Sector fields
+        assert "'main_sector': '9638cecc-5f95-e211-a939-e4115bead28a'" in str(
+            patch_call_list[4]
+        )
+        assert "'sectors': []" in str(patch_call_list[4])
+        assert "'sectors_affected': True" in str(patch_call_list[4])
+        # Companies fields
+        assert "'companies': [{'id': '10590916', 'name': 'BLAH LTD'}]" in str(
+            patch_call_list[5]
+        )
+        assert "'related_organisations': []" in str(patch_call_list[5])
+        # Export types fields
+        patch_call_list[6]
+        assert "'export_types': ['goods', 'services']" in str(patch_call_list[6])
+        assert "'export_description': 'A description of the export.'" in str(
+            patch_call_list[6]
+        )
+        assert (
+            "'commodities': [{'code': '1001000000', "
+            "'country': '80756b9a-5d95-e211-a939-e4115bead28a', 'trading_bloc': ''}]"
+        ) in str(patch_call_list[6])
+        assert (
+            "'public_eligibility': True, " "'public_eligibility_summary': ''"
+        ) in str(patch_call_list[7])
+
+        # Assert the report submit mock was called a single time
+        report_submit_patch.assert_called_once()
+
+        # Assert the public barrier was marked as in-progress a single time
+        public_barrier_patch.call_count == 0

--- a/utils/api/resources.py
+++ b/utils/api/resources.py
@@ -349,6 +349,31 @@ class PublicBarriersResource(APIResource):
     def mark_as_in_progress(self, id):
         return self.client.post(f"{self.resource_name}/{id}/unprepared")
 
+    def ready_for_approval(self, id):
+        return self.client.post(f"{self.resource_name}/{id}/ready-for-approval")
+
+    def ready_for_publishing(self, id):
+        return self.client.post(f"{self.resource_name}/{id}/ready-for-publishing")
+
+    def allow_for_publishing_process(self, id):
+        return self.client.post(
+            f"{self.resource_name}/{id}/allow-for-publishing-process"
+        )
+
+    def report_public_barrier_field(self, id, *args, **kwargs):
+        form_name = kwargs["form_name"]
+        # Endpoint field to update depends on the report a barrier form used to submit data.
+        if form_name == "barrier-public-title":
+            return self.client.post(
+                f"{self.resource_name}/{id}/report_public_barrier_title", json=kwargs
+            )
+        elif form_name == "barrier-public-summary":
+            return self.client.post(
+                f"{self.resource_name}/{id}/report_public_barrier_summary", json=kwargs
+            )
+        else:
+            return "Error."
+
     def mark_as_ready(self, id):
         return self.client.post(f"{self.resource_name}/{id}/ready")
 


### PR DESCRIPTION
* Adding public title/summary/eligibility to MVE journey

* Fix and move setup to own function in utest

* Review comments

* Fixing public_barrier update on MVE for general users - permissions relaxing

* Extending old unit tests to match new possible endings to MVE flow

* Tests and minor bugfixes for MVE MAU bolt ons (#621)

* Tests and minor bugfixes for MVE MAU bolt ons

* UAT Review fixes

* Fixing bug where switching branch paths causes keyerror

* Copy change for 'Can be Published' in MVE journey

---------



* Update error messages and character count

* Unit test update for wordcount

* Tss 1519 general user journey mau rebase on mve bolt on (#625)

* General user journey for public-barriers MAU project

* Adding edit pages and fixing flow for general users in MAU

* Minor fixes

* Adding unit tests for new public barrier forms

* Fixing link to barrier info tab on public barrier page

* Tab badge fix for new statuses

* Minor renaming of CSS elements

* Adding Approver user functions to public view page (#628)

* Adding Approver user functions to public view page

* Updating unit tests fith User group stubbing

* Tests for approval form

* Missing dict key mitigation

---------



---------



---------



Merge error - button colour re-added

Publisher journey changes for MAU (#631)

* Publisher journey changes for MAU

* Content changes for status box

* Minor refactors

* Adding date countdown

* Change Edit Approvers to Edit List

* Fixes for search page

* Unit tests improve MAU coverage

* Adding banner using django messages to inform user of changes to publ… (#637)

* Adding banner using django messages to inform user of changes to public view status

* Remove mark-safe from django template

* Updating old unit tests

* Fixing circleci unit test compatabliity

* Adding testing for message generation

* Fixing CSS of success message banner

---------



---------